### PR TITLE
fix(config): Use named bin in lintstagedrc.js

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,15 @@
         "infra",
         "test"
       ]
+    },
+    {
+      "login": "sudo-suhas",
+      "name": "Suhas Karanth",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/22251956?v=4",
+      "profile": "https://github.com/sudo-suhas",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![downloads][downloads-badge]][npmcharts]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Code of Conduct][coc-badge]][coc]
 
@@ -107,8 +107,8 @@ here! Again, this is a very specific-to-me solution.
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Tests") |
-| :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Tests") | [<img src="https://avatars2.githubusercontent.com/u/22251956?v=4" width="100px;"/><br /><sub>Suhas Karanth</sub>](https://github.com/sudo-suhas)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=sudo-suhas "Code") |
+| :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "test:update": "node src test --updateSnapshot",
     "build": "node src build",
     "lint": "node src lint",
+    "format": "node src format",
     "validate": "node src validate",
-    "precommit": "node src precommit"
+    "precommit": "node src precommit",
+    "kcd-scripts": "dist/index.js"
   },
   "files": ["dist", "babel.js", "eslint.js", "config.js"],
   "keywords": [],

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -1,19 +1,15 @@
-const [executor] = process.argv
-
-const scripts = `${executor} ${require.resolve('../')}`
-
 module.exports = {
   linters: {
     '**/*.+(js|json|less|css|ts)': [
-      `${scripts} format`,
-      `${scripts} lint`,
-      `${scripts} test --findRelatedTests`,
+      'kcd-scripts format',
+      'kcd-scripts lint',
+      'kcd-scripts test --findRelatedTests',
       'git add',
     ],
     '.all-contributorsrc': [
       // lint-staged passes arguments to the scripts.
       // to avoid passing these arguments, we do the echo thing
-      `${scripts} contributors generate`,
+      'kcd-scripts contributors generate',
       'git add README.md',
     ],
   },


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fix a bug on windows related to `lint-staged` config.

<!-- Why are these changes necessary? -->
**Why**:
On windows, this happens when trying to run lint-staged:
```
λ git commit
husky > npm run -s precommit (node v8.5.0)

25l[08:47:32] Running tasks for **/*.+(js|json|less|css|ts) [started]
[08:47:32] Running tasks for .all-contributorsrc [started]
[08:47:32] Running tasks for .all-contributorsrc [skipped]
[08:47:32] → No staged files match .all-contributorsrc
[08:47:32] C:\Program Files\nodejs\node.exe E:\Projects\repos\glamorous\node_modules\kcd-scripts\dist\index.js format [started]
[08:47:32] C:\Program Files\nodejs\node.exe E:\Projects\repos\glamorous\node_modules\kcd-scripts\dist\index.js format [failed]
[08:47:32] → C:\Program could not be found. Try `npm install C:\Program`.
[08:47:32] Running tasks for **/*.+(js|json|less|css|ts) [failed]
[08:47:32] → C:\Program could not be found. Try `npm install C:\Program`.
25hC:\Program could not be found. Try `npm install C:\Program`.
25h
husky > pre-commit hook failed (add --no-verify to bypass)
```

<!-- How were these changes implemented? -->
**How**:
In the `lintstagedrc.js`, instead of using absolute paths to node binary and `kcd-scripts` binary, used the named bin itself. `lint-staged` is smart enough to figure out the rest.

I added an entry in `package.json>scripts` required for `lint-staged` to work in this repo. I also added a script for formatting. Hope that's alright.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
To be clear, how the named binary works, is different in this repo and others. In this repo, in order for `lint-staged` to know what `kcd-scripts` means, the `scripts` entry in `package.json` helps it resolve it to `dist/index.js`. In all other repos, `lint-staged` looks and resolves `kcd-scripts` by peeking into `node_modules/.bin`.

Closes #2.