### PR TITLE
fix: Filter undefined values from process.env before spawn

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -25,7 +25,8 @@
       "avatar_url": "https://avatars2.githubusercontent.com/u/22251956?v=4",
       "profile": "https://github.com/sudo-suhas",
       "contributions": [
-        "code"
+        "code",
+        "bug"
       ]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ here! Again, this is a very specific-to-me solution.
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Tests") | [<img src="https://avatars2.githubusercontent.com/u/22251956?v=4" width="100px;"/><br /><sub>Suhas Karanth</sub>](https://github.com/sudo-suhas)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=sudo-suhas "Code") |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/kcd-scripts/commits?author=kentcdodds "Tests") | [<img src="https://avatars2.githubusercontent.com/u/22251956?v=4" width="100px;"/><br /><sub>Suhas Karanth</sub>](https://github.com/sudo-suhas)<br />[💻](https://github.com/kentcdodds/kcd-scripts/commits?author=sudo-suhas "Code") [🐛](https://github.com/kentcdodds/kcd-scripts/issues?q=author%3Asudo-suhas "Bug reports") |
 | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ if (!scriptPath) {
   console.log('Perhaps you need to update kcd-scripts?')
 }
 
+// this is required to address an issue in cross-spawn
+// https://github.com/kentcdodds/kcd-scripts/issues/4
 const env = Object.keys(process.env)
   .filter(key => process.env[key] !== undefined)
   .reduce(

--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,21 @@ if (!scriptPath) {
   console.log('Perhaps you need to update kcd-scripts?')
 }
 
+const env = Object.keys(process.env)
+  .filter(key => process.env[key] !== undefined)
+  .reduce(
+    (envCopy, key) => {
+      envCopy[key] = process.env[key]
+      return envCopy
+    },
+    {
+      [`SCRIPTS_${script.toUpperCase()}`]: true,
+    },
+  )
+
 const result = spawn.sync(executor, [scriptPath, ...args], {
   stdio: 'inherit',
-  env: Object.assign({}, process.env, {
-    [`SCRIPTS_${script.toUpperCase()}`]: true,
-  }),
+  env,
 })
 
 if (result.signal) {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fixes a bug in `cross-spawn` invocation - #4

<!-- Why are these changes necessary? -->
**Why**:
Passing `undefined` values in `env` breaks npm.

<!-- How were these changes implemented? -->
**How**:
Filter and reduce `process.env` before passing to `cross-spawn`.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [X] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
Closes #4. I will also follow up with `cross-spawn`.