### PR TITLE
fix(usage): Fix available scripts message on Windows

### DIFF
--- a/src/run-script.js
+++ b/src/run-script.js
@@ -8,7 +8,10 @@ if (script) {
 } else {
   const scriptsPath = path.join(__dirname, 'scripts/')
   const scriptsAvailable = glob.sync(path.join(__dirname, 'scripts', '*'))
+  // `glob.sync` returns paths with unix style path separators even on Windows.
+  // So we normalize it before attempting to strip out the scripts path.
   const scriptsAvailableMessage = scriptsAvailable
+    .map(path.normalize)
     .map(s =>
       s
         .replace(scriptsPath, '')


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fix bug in usage message on windows.

<!-- Why are these changes necessary? -->
**Why**:
```
λ node src\index.js

Usage: E:\Projects\repos\kcd-scripts\src\index.js [script] [--flags]

Available Scripts:
  E:/Projects/repos/kcd-scripts/src/scripts/
  E:/Projects/repos/kcd-scripts/src/scripts/build
  E:/Projects/repos/kcd-scripts/src/scripts/contributors
  E:/Projects/repos/kcd-scripts/src/scripts/format
  E:/Projects/repos/kcd-scripts/src/scripts/lint
  E:/Projects/repos/kcd-scripts/src/scripts/precommit
  E:/Projects/repos/kcd-scripts/src/scripts/test
  E:/Projects/repos/kcd-scripts/src/scripts/travis-after-success
  E:/Projects/repos/kcd-scripts/src/scripts/validate

Options:
  All options depend on the script. Docs will be improved eventually, but for most scripts you can assume that the args you pass will be forwarded to the respective tool that's being run under the hood.

May the force be with you.
```
This happens because `glob.sync` returns file paths with unix style separators and our `replace(scriptsPath, '')` fails.

<!-- How were these changes implemented? -->
**How**:
Use `path.normalize` before trying to replace the `scriptsPath` from the file paths that `glob.sync` returns.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
