### PR TITLE
test: Fix failing tests on Windows

### DIFF
--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,16 +1,14 @@
 import path from 'path'
+import slash from 'slash'
 import cases from 'jest-in-case'
+import {unquoteSerializer} from '../scripts/__tests__/helpers/serializers'
 
-// this removes the quotes around strings...
-const projectRoot = path.join(__dirname, '../../').replace(/\\/g, '/')
+const projectRoot = path.join(__dirname, '../../')
 
+expect.addSnapshotSerializer(unquoteSerializer)
 expect.addSnapshotSerializer({
-  print(val) {
-    return val.split(projectRoot).join('<PROJECT_ROOT>/')
-  },
-  test(val) {
-    return typeof val === 'string'
-  },
+  print: val => slash(val.replace(projectRoot, '<PROJECT_ROOT>/')),
+  test: val => typeof val === 'string' && val.includes(projectRoot),
 })
 
 cases(

--- a/src/scripts/__tests__/validate.js
+++ b/src/scripts/__tests__/validate.js
@@ -75,10 +75,14 @@ function setupWithScripts(scripts = ['test', 'lint', 'build', 'flow']) {
 
 function setupWithArgs(args = []) {
   return function setup() {
+    const utils = require('../../utils')
+    const originalResolveBin = utils.resolveBin
+    utils.resolveBin = (modName, {executable = modName} = {}) => executable
     const originalArgv = process.argv
     process.argv = ['node', '../format', ...args]
     return function teardown() {
       process.argv = originalArgv
+      utils.resolveBin = originalResolveBin
     }
   }
 }


### PR DESCRIPTION
This fixes the tests which are failing on Windows:
- [`src\__tests__\index.js`] `format › calls node with the script path and args`
- [`src\scripts\__tests__\validate.js`] `validate › allows you to specify your
  own npm scripts`

<details>
<summary>verbose test output</summary>

```
[test]  FAIL  src\__tests__\index.js
[test]   ● format › calls node with the script path and args
[test]
[test]     expect(value).toMatchSnapshot()
[test]
[test]     Received value does not match stored snapshot 1.
[test]
[test]     - node <PROJECT_ROOT>/src/scripts/test.js --no-watch
[test]     + node E:\Projects\repos\kcd-scripts\src\scripts\test.js --no-watch
[test]
[test]       at Object.<anonymous> (src/__tests__/index.js:44:49)
[test]       at Object.cb (node_modules/jest-in-case/index.js:40:20)
[test]           at new Promise (<anonymous>)
[test]           at <anonymous>
[test]
[test]  › 1 snapshot test failed.
[test]  FAIL  src\scripts\__tests__\validate.js
[test]   ● validate › allows you to specify your own npm scripts
[test]
[test]     expect(value).toMatchSnapshot()
[test]
[test]     Received value does not match stored snapshot 1.
[test]
[test]     - concurrently --kill-others-on-fail --prefix [{name}] --names specialbuild,specialtest,speciallint --prefix-colors bgBlue.bold.reset,bgGreen.bold.reset,bgMagenta.bold.reset "npm run specialbuild --silent" "npm run specialtest --silent" "npm run speciallint --silent"
[test]     + .\node_modules\concurrently\src\main.js --kill-others-on-fail --prefix [{name}] --names specialbuild,specialtest,speciallint --prefix-colors bgBlue.bold.reset,bgGreen.bold.reset,bgMagenta.bold.reset "npm run specialbuild --silent" "npm run specialtest --silent" "npm run speciallint --silent"
[test]
[test]       at Object.<anonymous> (src/scripts/__tests__/validate.js:23:47)
[test]       at Object.cb (node_modules/jest-in-case/index.js:40:20)
[test]           at new Promise (<anonymous>)
[test]           at <anonymous>
[test]
[test]  › 1 snapshot test failed.
[test]
[test] Snapshot Summary
[test]  › 2 snapshot tests failed in 2 test suites. Inspect your code changes or run with `yarn test -- -u` to update them.
```

</details>