### PR TITLE
fix(config): Ensure env var BUILD_FILENAME_PREFIX is respected

### DIFF
--- a/src/config/rollup.config.js
+++ b/src/config/rollup.config.js
@@ -18,12 +18,13 @@ const isPreact = parseEnv('BUILD_PREACT', false)
 const isNode = parseEnv('BUILD_NODE', false)
 const name = process.env.BUILD_NAME || capitalize(camelcase(pkg.name))
 
-const defaultGlobals = Object.keys(
-  pkg.peerDependencies || {},
-).reduce((deps, dep) => {
-  deps[dep] = capitalize(camelcase(dep))
-  return deps
-}, {})
+const defaultGlobals = Object.keys(pkg.peerDependencies || {}).reduce(
+  (deps, dep) => {
+    deps[dep] = capitalize(camelcase(dep))
+    return deps
+  },
+  {},
+)
 
 const defaultExternal = Object.keys(pkg.peerDependencies || {})
 
@@ -33,7 +34,7 @@ const input =
 
 const filenameSuffix = process.env.BUILD_FILENAME_SUFFIX || ''
 const filenamePrefix =
-  process.env.BUILD_FILENAME_PREFIX || isPreact ? 'preact/' : ''
+  process.env.BUILD_FILENAME_PREFIX || (isPreact ? 'preact/' : '')
 const globals = parseEnv(
   'BUILD_GLOBALS',
   isPreact ? Object.assign(defaultGlobals, {preact: 'preact'}) : defaultGlobals,


### PR DESCRIPTION
Prior to this, setting BUILD_FILENAME_PREFIX would always cause
filenamePrefix to evaluate to 'preact/' since we would evaluate the
lefthand side of the expression for truthiness rather than existence,
causing it to read as
```js
(BUILD_FILENAME_PREFIX || isPreact) ? 'preact/' : ''
```
instead of 
```js
BUILD_FILENAME_PREFIX || (isPreact ? 'preact/' : '')
```