### PR TITLE
Always use 'named' exports in rollup.config.js

### DIFF
--- a/src/config/rollup.config.js
+++ b/src/config/rollup.config.js
@@ -71,7 +71,7 @@ const output = [
     name,
     file: filepath,
     format: esm ? 'es' : format,
-    exports: esm ? 'named' : 'default',
+    exports: 'named',
     globals,
   },
 ]


### PR DESCRIPTION
**What**:

Always use 'named' exports in rollup.config.js

**Why**:

Differentiating them was imho a mistake and also a breaking change when you have switched from using babel to rollup. It is also a reason why you need to do [such hacks](https://github.com/paypal/downshift/blob/master/src/index.js#L4-L9) in possibly every library using kcd-scripts. Using mentioned hack is preventing tree-shaking to take place, which is also a big downside of this approach. (I understand that i.e. downshift is "used or not" and it doesnt have to be any more tree-shakeable than that, but consider downshift being a dependency of other package - if one imports other package which in turns uses downshift as part of its tree-shakeable named export - downshift might not get tree-shaken from the bundle **at all**).

(!) Unfortunately this is gonna be a breaking change.

**Checklist**:

* [ ] Documentation N/A
* [ ] Tests N/A
* [ ] Ready to be merged >
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
