### PR TITLE
feat(babel): Wrap propTypes for better production DCE

### DIFF
--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -32,12 +32,10 @@ module.exports = {
     isPreact
       ? [require.resolve('babel-plugin-transform-react-jsx'), {pragma: 'h'}]
       : null,
-    isPreact
-      ? [
-          require.resolve('babel-plugin-transform-react-remove-prop-types'),
-          {removeImport: true},
-        ]
-      : null,
+    [
+      require.resolve('babel-plugin-transform-react-remove-prop-types'),
+      isPreact ? {removeImport: true} : {mode: 'unsafe-wrap'},
+    ],
     isUMD
       ? require.resolve('babel-plugin-transform-inline-environment-variables')
       : null,


### PR DESCRIPTION
If a library doesn't check its propTypes at runtime (and imho it shouldnt) then this is a safe optimization that can reduce bundle sizes a little bit.