### PR TITLE
Add rollup-plugin-replace

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lint-staged": "^6.0.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.has": "^4.5.2",
+    "lodash.omit": "^4.5.0",
     "mkdirp": "^0.5.1",
     "prettier": "^1.9.2",
     "read-pkg-up": "^3.0.0",
@@ -72,6 +73,7 @@
     "rollup-plugin-node-builtins": "^2.1.2",
     "rollup-plugin-node-globals": "^1.1.0",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^2.0.1",
     "which": "^1.3.0",
     "yargs-parser": "^8.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -14,4 +14,5 @@ if (shouldThrow) {
       'because we dogfood the untranspiled version of the scripts.',
   )
 }
+
 require('./run-script')

--- a/src/scripts/build/rollup.js
+++ b/src/scripts/build/rollup.js
@@ -86,7 +86,7 @@ if (result.status === 0 && buildPreact && !args.includes('--no-package-json')) {
 
 function getPReactScripts() {
   const reactCommands = prefixKeys('react.', getCommands())
-  const preactCommands = prefixKeys('preact.', getCommands('BUILD_PREACT=true'))
+  const preactCommands = prefixKeys('preact.', getCommands({ preact: true }))
   return getConcurrentlyArgs(Object.assign(reactCommands, preactCommands))
 }
 
@@ -97,14 +97,24 @@ function prefixKeys(prefix, object) {
   }, {})
 }
 
-function getCommands(env = '') {
+function getCommands({
+  preact = false,
+} = {}) {
   return formats.reduce((cmds, format) => {
     const [formatName, minify = false] = format.split('.')
     const nodeEnv = minify ? 'production' : 'development'
     const sourceMap = formatName === 'umd' ? '--sourcemap' : ''
     const buildMinify = Boolean(minify)
+
     cmds[format] = getCommand(
-      `BUILD_FORMAT=${formatName} BUILD_MINIFY=${buildMinify} NODE_ENV=${nodeEnv} ${env}`,
+      [
+        `BUILD_FORMAT=${formatName}`,
+        `BUILD_MINIFY=${buildMinify}`,
+        `NODE_ENV=${nodeEnv}`,
+        `BUILD_PREACT=${preact}`,
+        `BUILD_NODE=${process.env.BUILD_NODE || false}`,
+        `BUILD_REACT_NATIVE=${process.env.BUILD_REACT_NATIVE || false}`,
+      ].join(' '),
       sourceMap
     )
     return cmds

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,7 +70,11 @@ const ifScript = ifPkgSubProp('scripts')
 
 function parseEnv(name, def) {
   if (envIsSet(name)) {
-    return JSON.parse(process.env[name])
+    try {
+      return JSON.parse(process.env[name])
+    } catch (err) {
+      return process.env[name]
+    }
   }
   return def
 }


### PR DESCRIPTION
* [ ] Documentation
* [x] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

This is a quick proof of concept, although this cannot be merged as is. Problem with this approach is that we'd have to know all possible keys upfront and pass their values to builds, otherwise they won't get replaced.

What can be done:
- standardize few keys and fill in their default in the config if they are not specified explicitly
- allow for extra keys (but they will suffer from the issue mentioned above)

WDYT?
