### PR TITLE
feat(rollup): Use code-splitting with multiple inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,10 @@
     "yargs-parser": "^10.0.0"
   },
   "eslintConfig": {
-    "extends": ["kentcdodds", "kentcdodds/jest"],
+    "extends": [
+      "kentcdodds",
+      "kentcdodds/jest"
+    ],
     "rules": {
       "no-process-exit": "off",
       "import/no-dynamic-require": "off",
@@ -88,7 +91,11 @@
       "no-nested-ternary": "off"
     }
   },
-  "eslintIgnore": ["node_modules", "coverage", "dist"],
+  "eslintIgnore": [
+    "node_modules",
+    "coverage",
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/kentcdodds/kcd-scripts.git"

--- a/src/run-script.js
+++ b/src/run-script.js
@@ -3,6 +3,7 @@ const spawn = require('cross-spawn')
 const glob = require('glob')
 
 const [executor, ignoredBin, script, ...args] = process.argv
+
 if (script) {
   spawnScript()
 } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,7 @@
 const fs = require('fs')
 const path = require('path')
+const rimraf = require('rimraf')
+const mkdirp = require('mkdirp')
 const arrify = require('arrify')
 const has = require('lodash.has')
 const readPkgUp = require('read-pkg-up')
@@ -138,6 +140,33 @@ function isOptedIn(key, t = true, f = false) {
   return contents.includes(key) ? t : f
 }
 
+function uniq(arr) {
+  return Array.from(new Set(arr))
+}
+
+function writeExtraEntry(name, {cjs, esm}, clean = true) {
+  if (clean) {
+    rimraf.sync(fromRoot(name))
+  }
+  mkdirp.sync(fromRoot(name))
+
+  const pkgJson = fromRoot(`${name}/package.json`)
+  const entryDir = fromRoot(name)
+
+  fs.writeFileSync(
+    pkgJson,
+    JSON.stringify(
+      {
+        main: path.relative(entryDir, cjs),
+        'jsnext:main': path.relative(entryDir, esm),
+        module: path.relative(entryDir, esm),
+      },
+      null,
+      2,
+    ),
+  )
+}
+
 module.exports = {
   appDirectory,
   envIsSet,
@@ -158,4 +187,6 @@ module.exports = {
   pkg,
   resolveBin,
   resolveKcdScripts,
+  uniq,
+  writeExtraEntry,
 }


### PR DESCRIPTION
**What**:

Allow for multiple inputs (with glob pattern) to be passed to rollup script, use `experimentalCodeSplitting` to bundle them in such case.

This dedupes common dependencies, if I use both:
```js
import rtlCssJs from 'rtl-css-js'
import { propertyValueConverters } from 'rtl-css-js/core'
```
I won't end up with duplicated code responsible for `propertyValueConverters`.

**Checklist**:

* [ ] Documentation
* [ ] Tests
* [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

How I plan to use it can be seen [here](https://github.com/Andarist/rtl-css-js/commit/97bbf55e68aa27f5b79a14845ff8a6375ff45a0f). I've developed this feature because of it, and Ive tested it locally on that commit by `npm link`ing