### PR TITLE
feat(babel): make the config of browserslist could be overrode by user

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
+    "browserslist": "^3.2.8",
     "concurrently": "^3.5.1",
     "cross-env": "^5.1.4",
     "cross-spawn": "^6.0.5",

--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -1,4 +1,6 @@
-const {ifAnyDep, parseEnv} = require('../utils')
+const browserslist = require('browserslist')
+
+const {ifAnyDep, parseEnv, appDirectory} = require('../utils')
 
 const isTest = (process.env.BABEL_ENV || process.env.NODE_ENV) === 'test'
 const isPreact = parseEnv('BUILD_PREACT', false)
@@ -8,9 +10,21 @@ const isWebpack = parseEnv('BUILD_WEBPACK', false)
 const treeshake = parseEnv('BUILD_TREESHAKE', isRollup || isWebpack)
 const alias = parseEnv('BUILD_ALIAS', isPreact ? {react: 'preact'} : null)
 
+/**
+ * use the strategy declared by browserslist to load browsers configuration.
+ * fallback to the default if don't found custom configuration
+ * @see https://github.com/browserslist/browserslist/blob/master/node.js#L139
+ */
+const browsersConfig = browserslist.loadConfig({path: appDirectory}) || [
+  'ie 10',
+  'ios 7',
+]
+
 const envTargets = isTest
   ? {node: 'current'}
-  : isWebpack || isRollup ? {browsers: ['ie 10', 'ios 7']} : {node: '4.5'}
+  : isWebpack || isRollup
+    ? {browsers: browsersConfig}
+    : {node: '4.5'}
 const envOptions = {modules: false, loose: true, targets: envTargets}
 
 module.exports = {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

make the `browsers` option of `babel-preset-env` could be overridden by the user.

<!-- Why are these changes necessary? -->

**Why**:

This request has been described in #43 in detail.

<!-- How were these changes implemented? -->

**How**:

leverage the `loadConfig()` method of `browserslist`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation
* [ ] Tests
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

I have created a demo project to test this. It works, write tests for this is too hard, I have no idea ...