### PR TITLE
feat(rollup): Add size snapshot plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "rollup-plugin-node-globals": "^1.2.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-replace": "^2.0.0",
+    "rollup-plugin-size-snapshot": "^0.6.1",
     "rollup-plugin-uglify": "^3.0.0",
     "which": "^1.3.0",
     "yargs-parser": "^10.0.0"

--- a/src/config/rollup.config.js
+++ b/src/config/rollup.config.js
@@ -9,6 +9,7 @@ const replace = require('rollup-plugin-replace')
 const uglify = require('rollup-plugin-uglify')
 const nodeBuiltIns = require('rollup-plugin-node-builtins')
 const nodeGlobals = require('rollup-plugin-node-globals')
+const {sizeSnapshot} = require('rollup-plugin-size-snapshot')
 const omit = require('lodash.omit')
 const {
   pkg,
@@ -144,6 +145,7 @@ module.exports = {
       babelrc: true,
     }),
     replace(replacements),
+    sizeSnapshot(),
     minify ? uglify() : null,
     codeSplitting &&
       ((writes = 0) => ({


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Enables bundle size snapshots in a `.size-snapshot.json` file
<!-- Why are these changes necessary? -->

**Why**:
I think it would be really useful to be able to track the bundle sizes, also nice to get this info in PRs that adds third-party libs etc. But it should maybe be a opt-in feature?
<!-- How were these changes implemented? -->

**How**:
Just add the `rollup-plugin-size-snapshot` to `rollup.config.js`
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [ ] Documentation N/A
* [ ] Tests N/A
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
