### PR TITLE
feat: move size-snapshot behind a flag

### DIFF
--- a/src/config/rollup.config.js
+++ b/src/config/rollup.config.js
@@ -30,6 +30,7 @@ const format = process.env.BUILD_FORMAT
 const isPreact = parseEnv('BUILD_PREACT', false)
 const isNode = parseEnv('BUILD_NODE', false)
 const name = process.env.BUILD_NAME || capitalize(camelcase(pkg.name))
+const useSizeSnapshot = parseEnv('BUILD_SIZE_SNAPSHOT', false)
 
 const defaultGlobals = Object.keys(pkg.peerDependencies || {}).reduce(
   (deps, dep) => {
@@ -145,7 +146,7 @@ module.exports = {
       babelrc: true,
     }),
     replace(replacements),
-    sizeSnapshot(),
+    useSizeSnapshot ? sizeSnapshot({printInfo: false}) : null,
     minify ? terser() : null,
     codeSplitting &&
       ((writes = 0) => ({

--- a/src/scripts/build/rollup.js
+++ b/src/scripts/build/rollup.js
@@ -30,6 +30,7 @@ const environment = parsedArgs.environment
   ? `--environment ${parsedArgs.environment}`
   : ''
 const watch = parsedArgs.watch ? '--watch' : ''
+const sizeSnapshot = parsedArgs['size-snapshot']
 
 let formats = ['esm', 'cjs', 'umd', 'umd.min']
 
@@ -100,6 +101,7 @@ function getCommands({preact = false} = {}) {
         `BUILD_MINIFY=${buildMinify}`,
         `NODE_ENV=${nodeEnv}`,
         `BUILD_PREACT=${preact}`,
+        `BUILD_SIZE_SNAPSHOT=${sizeSnapshot}`,
         `BUILD_NODE=${process.env.BUILD_NODE || false}`,
         `BUILD_REACT_NATIVE=${process.env.BUILD_REACT_NATIVE || false}`,
       ].join(' '),


### PR DESCRIPTION
**What**:
Don't generate a `.size-snapshot.json` file by default
<!-- Why are these changes necessary? -->

**Why**:
Does not make sense for libraries like `react-testing-library` and other non browser related libs to generate this file
<!-- How were these changes implemented? -->

**How**:
Hide the functionality behind a `--size-snapshot` flag
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table N/A <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
