### PR TITLE
feat: support custom node version based on engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-size-snapshot": "^0.6.1",
     "rollup-plugin-terser": "^1.0.1",
+    "semver": "^5.5.1",
     "which": "^1.3.0",
     "yargs-parser": "^10.0.0"
   },


### PR DESCRIPTION
**What**: feat: support custom node version based on engines (falls back to node version 8).

<!-- Why are these changes necessary? -->

**Why**: So projects can more easily specifically target the version they need to support.

<!-- How were these changes implemented? -->

**How**: Using semver and getting the engines.node property in the package.json to determine the oldest version supported and transpile down to that.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A 😅 
- [ ] Tests N/A 😅 
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions --> N/A

<!-- feel free to add additional comments -->
