### PR TITLE
refactor(tests): removes mockClear

### DIFF
--- a/src/scripts/__tests__/format.js
+++ b/src/scripts/__tests__/format.js
@@ -17,7 +17,6 @@ cases(
 
     // tests
     process.argv = ['node', '../format', ...args]
-    crossSpawnSyncMock.mockClear()
     require('../format')
     expect(crossSpawnSyncMock).toHaveBeenCalledTimes(1)
     const [firstCall] = crossSpawnSyncMock.mock.calls

--- a/src/scripts/__tests__/lint.js
+++ b/src/scripts/__tests__/lint.js
@@ -26,7 +26,6 @@ cases(
     const teardown = setup()
 
     process.argv = ['node', '../lint', ...args]
-    crossSpawnSyncMock.mockClear()
 
     try {
       // tests

--- a/src/scripts/__tests__/precommit.js
+++ b/src/scripts/__tests__/precommit.js
@@ -25,7 +25,6 @@ cases(
 
     process.argv = ['node', '../pre-commit', ...args]
     utils.isOptedIn = optIn => optIn === 'pre-commit'
-    crossSpawnSyncMock.mockClear()
 
     try {
       // tests

--- a/src/scripts/__tests__/test.js
+++ b/src/scripts/__tests__/test.js
@@ -35,7 +35,6 @@ cases(
     const teardown = setup()
 
     process.argv = ['node', '../test', ...args]
-    jestRunMock.mockClear()
 
     try {
       // tests

--- a/src/scripts/__tests__/travis-after-success.js
+++ b/src/scripts/__tests__/travis-after-success.js
@@ -31,7 +31,6 @@ cases(
     console.log = jest.fn()
 
     // tests
-    crossSpawnSyncMock.mockClear()
     if (version) {
       utils.pkg.version = version
     }

--- a/src/scripts/__tests__/validate.js
+++ b/src/scripts/__tests__/validate.js
@@ -15,7 +15,6 @@ cases(
 
     try {
       // tests
-      crossSpawnSyncMock.mockClear()
       require('../validate')
       expect(crossSpawnSyncMock).toHaveBeenCalledTimes(1)
       const [firstCall] = crossSpawnSyncMock.mock.calls


### PR DESCRIPTION
Because we recreate mockFn on each before