### PR TITLE
test: force jest to exit when there are open async handles after tests have finished running

### DIFF
--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -30,6 +30,7 @@ const jestConfig = {
       statements: 100,
     },
   },
+  forceExit: true,
 }
 
 if (useBuiltInBabelConfig) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Force jest to exit when there are open async handles after tests have finished running

<!-- Why are these changes necessary? -->

**Why**:
In some cases there may be harmless handles lying around, when tests have finished running.

<!-- How were these changes implemented? -->

**How**:
Me

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
