### PR TITLE
fix(rollup): remove experimentalCodeSplitting from config

### DIFF
--- a/src/config/rollup.config.js
+++ b/src/config/rollup.config.js
@@ -139,7 +139,6 @@ const replacements = Object.entries(
 module.exports = {
   input: codeSplitting ? input : input[0],
   output,
-  experimentalCodeSplitting: codeSplitting,
   external: externalPredicate,
   plugins: [
     isNode ? nodeBuiltIns() : null,

--- a/src/scripts/build/rollup.js
+++ b/src/scripts/build/rollup.js
@@ -23,8 +23,8 @@ const useBuiltinConfig =
 const config = useBuiltinConfig
   ? `--config ${hereRelative('../../config/rollup.config.js')}`
   : args.includes('--config')
-    ? ''
-    : '--config' // --config will pick up the rollup.config.js file
+  ? ''
+  : '--config' // --config will pick up the rollup.config.js file
 
 const environment = parsedArgs.environment
   ? `--environment ${parsedArgs.environment}`


### PR DESCRIPTION
**What**: removing `experimentalCodeSplitting` from the rollup config

**Why**: as of rollup 1.0.0, the functionality provided by `experimentalCodeSplitting` is always active.  The option has been removed and now throws a warning when part of the rollup config.

**How**: removed the `experimentalCodeSplitting` from `src/config/rollup.config.js`

**Checklist**:

- [ ] Documentation - N/A
- [x] Tests - existing tests pass
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
