### PR TITLE
fix(resolveBin): windows will resolve to .cmd binaries if available (#8)

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -51,6 +51,25 @@ test(`resolveBin resolves to the binary if it's in $PATH`, () => {
   expect(whichSyncMock).toHaveBeenCalledWith('cross-env')
 })
 
+describe('for windows', () => {
+  let realpathSync
+
+  beforeEach(() => {
+    jest.doMock('fs', () => ({realpathSync: jest.fn()}))
+    realpathSync = require('fs').realpathSync
+  })
+  afterEach(() => {
+    jest.unmock('fs')
+  })
+
+  test('resolveBin resolves to .bin path when which returns a windows-style cmd', () => {
+    const fullBinPath = '\\project\\node_modules\\.bin\\concurrently.CMD'
+    realpathSync.mockImplementation(() => fullBinPath)
+    expect(require('../utils').resolveBin('concurrently')).toBe(fullBinPath)
+    expect(realpathSync).toHaveBeenCalledTimes(2)
+  })
+})
+
 test('getConcurrentlyArgs gives good args to pass to concurrently', () => {
   expect(
     require('../utils').getConcurrentlyArgs({

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,6 +24,7 @@ function resolveBin(modName, {executable = modName, cwd = process.cwd()} = {}) {
   let pathFromWhich
   try {
     pathFromWhich = fs.realpathSync(which.sync(executable))
+    if (pathFromWhich && pathFromWhich.includes('.CMD')) return pathFromWhich
   } catch (_error) {
     // ignore _error
   }


### PR DESCRIPTION
**What**: fixes #8

**Why**: Developers using windows could not run build using the --bundle flag because of the way windows resolves bins. This was blocking some devs on my team from adopting kcd-scripts.

**How**: by returning early when pathFromWhich resolves a .cmd file (only happens on windows environments)

**Checklist**:

- [ ] Documentation N/A
- [x ] Tests
- [x ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
