### PR TITLE
Add support for vue files

### DIFF
--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -5,7 +5,7 @@ const doctoc = resolveBin('doctoc')
 
 module.exports = {
   'README.md': [`${doctoc} --maxlevel 3 --notitle`, 'git add'],
-  '*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx)': [
+  '*.+(js|jsx|json|yml|yaml|css|less|scss|ts|tsx|md|graphql|mdx|vue)': [
     isOptedOut('autoformat', null, `${kcdScripts} format`),
     `${kcdScripts} lint`,
     `${kcdScripts} test --findRelatedTests`,


### PR DESCRIPTION
As discussed in https://github.com/testing-library/vue-testing-library/pull/86#discussion_r314949006, I'm adding support for `.vue` files in your `pre-commit` hook.

Offering full support for Vue would require several other modifications, but it feels out of the scope (at least for now - happy to help if I'm mistaken). Lint-staged was the only piece I couldn't get up and running.

Thanks for this! 🙌 