### PR TITLE
Fix/locate all prettier configs

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -143,6 +143,15 @@
       "contributions": [
         "fundingFinding"
       ]
+    },
+    {
+      "login": "schaab",
+      "name": "Jared Schaab",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/1103255?v=4",
+      "profile": "https://github.com/schaab",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "repoType": "github",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.21",
     "browserslist": "^4.6.6",
     "concurrently": "^4.1.1",
+    "cosmiconfig": "^5.2.1",
     "cross-env": "^5.1.4",
     "cross-spawn": "^6.0.5",
     "doctoc": "^1.4.0",

--- a/src/scripts/format.js
+++ b/src/scripts/format.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const spawn = require('cross-spawn')
 const yargsParser = require('yargs-parser')
-const {hasPkgProp, resolveBin, hasFile} = require('../utils')
+const {resolveBin, hasFile, hasLocalConfig} = require('../utils')
 
 const args = process.argv.slice(2)
 const parsedArgs = yargsParser(args)
@@ -10,10 +10,7 @@ const here = p => path.join(__dirname, p)
 const hereRelative = p => here(p).replace(process.cwd(), '.')
 
 const useBuiltinConfig =
-  !args.includes('--config') &&
-  !hasFile('.prettierrc') &&
-  !hasFile('prettier.config.js') &&
-  !hasPkgProp('prettierrc')
+  !args.includes('--config') && !hasLocalConfig('prettier')
 const config = useBuiltinConfig
   ? ['--config', hereRelative('../config/prettierrc.js')]
   : []

--- a/src/utils.js
+++ b/src/utils.js
@@ -173,7 +173,7 @@ function hasLocalConfig(moduleName, searchOptions = {}) {
   const explorer = cosmiconfig(moduleName, searchOptions)
   const result = explorer.searchSync(pkgPath)
 
-  return result !== null || !result.isEmpty
+  return result !== null
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,7 @@ const arrify = require('arrify')
 const has = require('lodash.has')
 const readPkgUp = require('read-pkg-up')
 const which = require('which')
+const cosmiconfig = require('cosmiconfig')
 
 const {package: pkg, path: pkgPath} = readPkgUp.sync({
   cwd: fs.realpathSync(process.cwd()),
@@ -168,12 +169,20 @@ function writeExtraEntry(name, {cjs, esm}, clean = true) {
   )
 }
 
+function hasLocalConfig(moduleName, searchOptions = {}) {
+  const explorer = cosmiconfig(moduleName, searchOptions)
+  const result = explorer.searchSync(pkgPath)
+
+  return result !== null || !result.isEmpty
+}
+
 module.exports = {
   appDirectory,
   envIsSet,
   fromRoot,
   getConcurrentlyArgs,
   hasFile,
+  hasLocalConfig,
   hasPkgProp,
   hasScript,
   ifAnyDep,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

Fixes #96 

**What**:

The `format` command does not recognize all local configuration file types

**Why**:

The docs state that the tool will respect a local configuration for a tool and use that over the default.

**How**:

Leverage `cosmiconfig` to search for any type of local configuration. `Prettier` uses it for config file support. This allows us to look for a module name rather than maintaining a list of files types to look for.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
