### PR TITLE
Update cross-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "browserslist": "^4.7.2",
     "concurrently": "^5.0.0",
     "cosmiconfig": "^5.2.1",
-    "cross-env": "^5.2.1",
+    "cross-env": "^6.0.3",
     "cross-spawn": "^7.0.1",
     "doctoc": "^1.4.0",
     "eslint": "^6.6.0",

--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -47,13 +47,13 @@ test('resolveKcdScripts resolves to kcd-scripts if not in the kcd-scripts packag
 
 test(`resolveBin resolves to the full path when it's not in $PATH`, () => {
   expect(require('../utils').resolveBin('cross-env')).toBe(
-    require.resolve('cross-env/dist/bin/cross-env').replace(process.cwd(), '.'),
+    require.resolve('cross-env/src/bin/cross-env').replace(process.cwd(), '.'),
   )
 })
 
 test(`resolveBin resolves to the binary if it's in $PATH`, () => {
   whichSyncMock.mockImplementationOnce(() =>
-    require.resolve('cross-env/dist/bin/cross-env').replace(process.cwd(), '.'),
+    require.resolve('cross-env/src/bin/cross-env').replace(process.cwd(), '.'),
   )
   expect(require('../utils').resolveBin('cross-env')).toBe('cross-env')
   expect(whichSyncMock).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Updated `cross-env` so you could see the failing test (like you asked in https://github.com/kentcdodds/kcd-scripts/pull/99#issuecomment-547660312)