### PR TITLE
Add support for custom scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "node src build",
     "lint": "node src lint",
     "format": "node src format",
-    "validate": "node src validate"
+    "validate": "node src validate",
+    "prepare": "node src build"
   },
   "husky": {
     "hooks": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,4 +15,4 @@ if (shouldThrow) {
   )
 }
 
-require('./run-script')
+require('./run-script')()


### PR DESCRIPTION
**What**:

Add support for overriding or creating custom scripts.

**Why**:

Rather than making a fork, create custom scripts on top of kcd-scripts

**How**:

By passing custom scripts path to run-script. 
Example https://github.com/piecyk/custom-kcd-scripts

**Checklist**:

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
