### PR TITLE
Let Jest ignore __fixtures__ & __tests__/utils too

### DIFF
--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -7,8 +7,10 @@ const useBuiltInBabelConfig = !hasFile('.babelrc') && !hasPkgProp('babel')
 
 const ignores = [
   '/node_modules/',
+  '/__fixtures__/',
   '/fixtures/',
   '/__tests__/helpers/',
+  '/__tests__/utils/',
   '__mocks__',
 ]
 


### PR DESCRIPTION
**What**:
Let Jest ignore `__fixtures__` & `__tests__/utils` too

**Why**:
- I think `__fixtures__` is more commonly used, since it's more in line with `__mocks__` & `__tests__`
- `utils` is evenly common to `helpers` I think

**How**:
Expand the ignore array

**Checklist**:
- [N/A] Documentation
- [N/A] Tests
- [x] Ready to be merged