### PR TITLE
feat: Allow debugging kcd-scripts for allow debugging unit tests

### DIFF
--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -2,6 +2,8 @@
 
 exports[`format calls node with the script path and args 1`] = `node <PROJECT_ROOT>/src/scripts/test.js --no-watch`;
 
+exports[`format calls node with the script path and args including inspect-brk argument 1`] = `node --inspect-brk=3080 <PROJECT_ROOT>/src/scripts/test.js --no-watch`;
+
 exports[`format does not log for other signals 1`] = `Array []`;
 
 exports[`format logs for SIGKILL signal 1`] = `

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -59,6 +59,9 @@ cases(
     'calls node with the script path and args': {
       args: ['test', '--no-watch'],
     },
+    'calls node with the script path and args including inspect-brk argument': {
+      args: ['--inspect-brk=3080', 'test', '--no-watch'],
+    },
     'throws unknown script': {
       args: ['unknown-script'],
       throws: true,

--- a/src/run-script.js
+++ b/src/run-script.js
@@ -2,7 +2,7 @@ const path = require('path')
 const spawn = require('cross-spawn')
 const glob = require('glob')
 
-const [executor, ignoredBin, script, ...args] = process.argv
+const [executor, ignoredBin, script] = process.argv
 
 if (script) {
   spawnScript()
@@ -53,16 +53,41 @@ function getEnv() {
 }
 
 function spawnScript() {
-  const relativeScriptPath = path.join(__dirname, './scripts', script)
-  const scriptPath = attemptResolve(relativeScriptPath)
+  // get all the arguments of the script and find the position of our script commands
+  const args = process.argv.slice(2)
+  const scriptIndex = args.findIndex(
+    x =>
+      x === 'format' ||
+      x === 'lint' ||
+      x === 'pre-commit' ||
+      x === 'test' ||
+      x === 'validate' ||
+      x === 'build',
+  )
 
+  // Extract the node arguments so we can pass them to node later on
+  const buildCommand = scriptIndex === -1 ? args[0] : args[scriptIndex]
+  const nodeArgs = scriptIndex > 0 ? args.slice(0, scriptIndex) : []
+
+  if (!buildCommand) {
+    throw new Error(`Unknown script "${script}".`)
+  }
+
+  const relativeScriptPath = path.join(__dirname, './scripts', buildCommand)
+  const scriptPath = attemptResolve(relativeScriptPath)
   if (!scriptPath) {
     throw new Error(`Unknown script "${script}".`)
   }
-  const result = spawn.sync(executor, [scriptPath, ...args], {
-    stdio: 'inherit',
-    env: getEnv(),
-  })
+
+  // Attempt to strt the script with the passed node arguments
+  const result = spawn.sync(
+    executor,
+    nodeArgs.concat(scriptPath).concat(args.slice(scriptIndex + 1)),
+    {
+      stdio: 'inherit',
+      env: getEnv(),
+    },
+  )
 
   if (result.signal) {
     handleSignal(result)


### PR DESCRIPTION
…e running

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
A small change has been made to the `run-script`-file to allow it to pass node arguments.

**Why**:
Currently you are not able to debug unit tests when running `kcd-scripts run test` this change will allow you to pass the `--inspect-brk`-argument so that breakpoints work.

**How**:
Now the script doesn't assume that the first argument is the command to be ran. Instead it will dig up the whitelisted commands from the arguments list and accordingly keep track of node arguments so they can be passed along when spawning the process

**Checklist**:
- [ ] Documentation
- [X] Tests
- [X] Ready to be merged

I am not sure if we want to document this?