### PR TITLE
chore: Update default Node version for Babel

### DIFF
--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -81,7 +81,7 @@ module.exports = () => ({
   ].filter(Boolean),
 })
 
-function getNodeVersion({engines: {node: nodeVersion = '8'} = {}}) {
+function getNodeVersion({engines: {node: nodeVersion = '10.13'} = {}}) {
   const oldestVersion = semver
     .validRange(nodeVersion)
     .replace(/[>=<|]/g, ' ')


### PR DESCRIPTION
BREAKING CHANGE: Requires Node 10.13+

People who rely on the default behaviour (having no `engines.node` key in their `package.json`), will now have compiled source for Node 10.13 instead of 8.