### PR TITLE
Expose husky config

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/config/huskyrc')

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/config/huskyrc')
+module.exports = require('./src/config/huskyrc')

--- a/husky.js
+++ b/husky.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/config/huskyrc')

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
   "files": [
     "dist",
     "babel.js",
-    "eslint.js",
     "config.js",
-    "prettier.js",
-    "jest.js"
+    "eslint.js",
+    "husky.js",
+    "jest.js",
+    "prettier.js"
   ],
   "keywords": [],
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com)",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,6 @@
     "format": "node src format",
     "validate": "node src validate"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "node src pre-commit"
-    }
-  },
   "files": [
     "dist",
     "babel.js",

--- a/src/config/huskyrc.js
+++ b/src/config/huskyrc.js
@@ -1,0 +1,9 @@
+const {resolveKcdScripts} = require('../utils')
+
+const kcdScripts = resolveKcdScripts()
+
+module.exports = {
+  hooks: {
+    'pre-commit': `${kcdScripts} pre-commit`,
+  },
+}

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   babel: require('./babelrc'),
   eslint: require('./eslintrc'),
+  husky: require('./huskyrc'),
   jest: require('./jest.config'),
   lintStaged: require('./lintstagedrc'),
   prettier: require('./prettierrc'),


### PR DESCRIPTION
If this one's merged, people could use the following `.huskyrc.js`:

```js
module.exports = require('kcd-scripts/husky');
```

instead of

```js
module.exports = {
  hooks: {
    'pre-commit': 'kcd-scripts pre-commit',
  },
}
```