### PR TITLE
Handle edge case in validate script

### DIFF
--- a/src/scripts/__tests__/__snapshots__/validate.js.snap
+++ b/src/scripts/__tests__/__snapshots__/validate.js.snap
@@ -13,3 +13,5 @@ exports[`validate does not include "lint" if it doesn't have that script 1`] = `
 exports[`validate does not include "test" if it doesn't have that script 1`] = `concurrently --kill-others-on-fail --prefix [{name}] --names build,lint,flow --prefix-colors bgBlue.bold.reset,bgGreen.bold.reset,bgMagenta.bold.reset "npm run build --silent" "npm run lint --silent" "npm run flow --silent"`;
 
 exports[`validate doesn't use test or lint if it's in pre-commit 1`] = `concurrently --kill-others-on-fail --prefix [{name}] --names build,flow --prefix-colors bgBlue.bold.reset,bgGreen.bold.reset "npm run build --silent" "npm run flow --silent"`;
+
+exports[`validate exits if there are no scripts to be run 1`] = ``;

--- a/src/scripts/__tests__/validate.js
+++ b/src/scripts/__tests__/validate.js
@@ -16,9 +16,8 @@ cases(
     try {
       // tests
       require('../validate')
-      expect(crossSpawnSyncMock).toHaveBeenCalledTimes(1)
       const [firstCall] = crossSpawnSyncMock.mock.calls
-      const [script, calledArgs] = firstCall
+      const [script, calledArgs] = firstCall || ['', []]
       expect([script, ...calledArgs].join(' ')).toMatchSnapshot()
     } catch (error) {
       throw error
@@ -57,6 +56,9 @@ cases(
           process.env['SCRIPTS_PRE-COMMIT'] = previousVal
         }
       }),
+    },
+    'exits if there are no scripts to be run': {
+      setup: withDefaultSetup(setupWithScripts([])),
     },
   },
 )

--- a/src/scripts/validate.js
+++ b/src/scripts/validate.js
@@ -29,10 +29,16 @@ const scripts = useDefaultScripts
       return scriptsToRun
     }, {})
 
-const result = spawn.sync(
-  resolveBin('concurrently'),
-  getConcurrentlyArgs(scripts),
-  {stdio: 'inherit'},
-)
+const scriptCount = Object.values(scripts).filter(Boolean).length
 
-process.exit(result.status)
+if (scriptCount > 0) {
+  const result = spawn.sync(
+    resolveBin('concurrently'),
+    getConcurrentlyArgs(scripts),
+    {stdio: 'inherit'},
+  )
+
+  process.exit(result.status)
+} else {
+  process.exit(0)
+}


### PR DESCRIPTION
**What**:

Fix a bug in the `validate` script.

**Why**:

The `validate` script currently assumes *at least* one script will be run, however I ran into an edge case where no scripts should be run which results in an error as `concurrently` is spawned without any script arguments.

The particular edge case in which I came across this issue:
- The `validate` script is being spawned from the `pre-commit` script
- The package in which the scripts are run has no `build` or `flow` script defined in its `package.json`


**How**:

Only spawn `concurrently` if more than `0` scripts are queued to run.

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged