### PR TITLE
Implement TypeScript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,14 @@ add `@babel/preset-flow` to the `presets`-section.
 
 ### TypeScript Support
 
-If the `typescript` is a dependency on the project the
+If the `tsconfig.json`-file is present in the project root directory the
 `@babel/preset-typescript` will automatically get loaded when you use the
 default babel config that comes with `kcd-scripts`. If you customised your
 `.babelrc`-file you might need to manually add `@babel/preset-typescript` to the
 `presets`-section.
 
 `kcd-scripts` will automatically load any `.ts` and `.tsx` files, including the
-default entry point, so you don't have to worry about rollup configuration.
+default entry point, so you don't have to worry about any rollup configuration.
 
 ## Inspiration
 

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ add `@babel/preset-flow` to the `presets`-section.
 
 ### TypeScript Support
 
-If the `tsconfig.json`-file is present in the project root directory the
-`@babel/preset-typescript` will automatically get loaded when you use the
-default babel config that comes with `kcd-scripts`. If you customised your
-`.babelrc`-file you might need to manually add `@babel/preset-typescript` to the
-`presets`-section.
+If the `tsconfig.json`-file is present in the project root directory and the
+`typescript` is a dependency the `@babel/preset-typescript` will automatically
+get loaded when you use the default babel config that comes with `kcd-scripts`.
+If you customised your `.babelrc`-file you might need to manually add
+`@babel/preset-typescript` to the `presets`-section.
 
 `kcd-scripts` will automatically load any `.ts` and `.tsx` files, including the
 default entry point, so you don't have to worry about any rollup configuration.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ for linting, testing, building, and more.
 - [Usage](#usage)
   - [Overriding Config](#overriding-config)
   - [Flow support](#flow-support)
+  - [TypeScript Support](#typescript-support)
 - [Inspiration](#inspiration)
 - [Other Solutions](#other-solutions)
 - [Issues](#issues)
@@ -121,6 +122,17 @@ If the `flow-bin` is a dependency on the project the `@babel/preset-flow` will
 automatically get loaded when you use the default babel config that comes with
 `kcd-scripts`. If you customised your `.babelrc`-file you might need to manually
 add `@babel/preset-flow` to the `presets`-section.
+
+### TypeScript Support
+
+If the `typescript` is a dependency on the project the
+`@babel/preset-typescript` will automatically get loaded when you use the
+default babel config that comes with `kcd-scripts`. If you customised your
+`.babelrc`-file you might need to manually add `@babel/preset-typescript` to the
+`presets`-section.
+
+`kcd-scripts` will automatically load any `.ts` and `.tsx` files, including the
+default entry point, so you don't have to worry about rollup configuration.
 
 ## Inspiration
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-flow": "^7.9.0",
     "@babel/preset-react": "^7.9.1",
+    "@babel/preset-typescript": "^7.9.0",
     "@babel/runtime": "^7.9.2",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-json": "^4.0.2",

--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -53,6 +53,7 @@ module.exports = () => ({
       ],
     ),
     ifAnyDep(['flow-bin'], [require.resolve('@babel/preset-flow')]),
+    ifAnyDep(['typescript'], [require.resolve('@babel/preset-typescript')]),
   ].filter(Boolean),
   plugins: [
     [

--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -1,7 +1,7 @@
 const browserslist = require('browserslist')
 const semver = require('semver')
 
-const {ifAnyDep, parseEnv, appDirectory, pkg} = require('../utils')
+const {ifAnyDep, parseEnv, appDirectory, pkg, ifFile} = require('../utils')
 
 const {BABEL_ENV, NODE_ENV, BUILD_FORMAT} = process.env
 const isTest = (BABEL_ENV || NODE_ENV) === 'test'
@@ -53,7 +53,7 @@ module.exports = () => ({
       ],
     ),
     ifAnyDep(['flow-bin'], [require.resolve('@babel/preset-flow')]),
-    ifAnyDep(['typescript'], [require.resolve('@babel/preset-typescript')]),
+    ifFile(['tsconfig.json'], [require.resolve('@babel/preset-typescript')]),
   ].filter(Boolean),
   plugins: [
     [

--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -1,7 +1,13 @@
 const browserslist = require('browserslist')
 const semver = require('semver')
 
-const {ifAnyDep, parseEnv, appDirectory, pkg, ifFile} = require('../utils')
+const {
+  ifAnyDep,
+  ifTypescript,
+  parseEnv,
+  appDirectory,
+  pkg,
+} = require('../utils')
 
 const {BABEL_ENV, NODE_ENV, BUILD_FORMAT} = process.env
 const isTest = (BABEL_ENV || NODE_ENV) === 'test'
@@ -53,7 +59,7 @@ module.exports = () => ({
       ],
     ),
     ifAnyDep(['flow-bin'], [require.resolve('@babel/preset-flow')]),
-    ifFile(['tsconfig.json'], [require.resolve('@babel/preset-typescript')]),
+    ifTypescript([require.resolve('@babel/preset-typescript')]),
   ].filter(Boolean),
   plugins: [
     [

--- a/src/config/rollup.config.js
+++ b/src/config/rollup.config.js
@@ -46,7 +46,7 @@ const deps = Object.keys(pkg.dependencies || {})
 const peerDeps = Object.keys(pkg.peerDependencies || {})
 const defaultExternal = umd ? peerDeps : deps.concat(peerDeps)
 
-const input = glob.sync(fromRoot(process.env.BUILD_INPUT || 'src/index.js'))
+const input = glob.sync(fromRoot(process.env.BUILD_INPUT || 'src/index.{js,ts,tsx}'))
 const codeSplitting = input.length > 1
 
 if (
@@ -136,6 +136,8 @@ const replacements = Object.entries(
   return acc
 }, {})
 
+const extensions = ['.js', '.ts', '.tsx'];
+
 module.exports = {
   input: codeSplitting ? input : input[0],
   output,
@@ -146,6 +148,7 @@ module.exports = {
     nodeResolve({
       preferBuiltins: isNode,
       mainFields: ['module', 'main', 'jsnext', 'browser'],
+      extensions,
     }),
     commonjs({include: 'node_modules/**'}),
     json(),
@@ -153,6 +156,7 @@ module.exports = {
       presets: babelPresets,
       babelrc: !useBuiltinConfig,
       runtimeHelpers: useBuiltinConfig,
+      extensions,
     }),
     replace(replacements),
     useSizeSnapshot ? sizeSnapshot({printInfo: false}) : null,

--- a/src/config/rollup.config.js
+++ b/src/config/rollup.config.js
@@ -15,7 +15,7 @@ const {
   pkg,
   hasFile,
   hasPkgProp,
-  hasAnyDep,
+  hasDep,
   hasTypescript,
   parseEnv,
   fromRoot,
@@ -166,7 +166,7 @@ module.exports = {
     rollupBabel({
       presets: babelPresets,
       babelrc: !useBuiltinConfig,
-      runtimeHelpers: hasAnyDep('@babel/runtime'),
+      runtimeHelpers: hasDep('@babel/runtime'),
       extensions,
     }),
     replace(replacements),

--- a/src/config/rollup.config.js
+++ b/src/config/rollup.config.js
@@ -15,6 +15,7 @@ const {
   pkg,
   hasFile,
   hasPkgProp,
+  hasAnyDep,
   parseEnv,
   fromRoot,
   uniq,
@@ -46,7 +47,9 @@ const deps = Object.keys(pkg.dependencies || {})
 const peerDeps = Object.keys(pkg.peerDependencies || {})
 const defaultExternal = umd ? peerDeps : deps.concat(peerDeps)
 
-const input = glob.sync(fromRoot(process.env.BUILD_INPUT || 'src/index.{js,ts,tsx}'))
+const input = glob.sync(
+  fromRoot(process.env.BUILD_INPUT || 'src/index.{js,ts,tsx}'),
+)
 const codeSplitting = input.length > 1
 
 if (
@@ -136,7 +139,7 @@ const replacements = Object.entries(
   return acc
 }, {})
 
-const extensions = ['.js', '.ts', '.tsx'];
+const extensions = ['.js', '.ts', '.tsx']
 
 module.exports = {
   input: codeSplitting ? input : input[0],
@@ -155,7 +158,7 @@ module.exports = {
     rollupBabel({
       presets: babelPresets,
       babelrc: !useBuiltinConfig,
-      runtimeHelpers: useBuiltinConfig,
+      runtimeHelpers: hasAnyDep('@babel/runtime'),
       extensions,
     }),
     replace(replacements),

--- a/src/config/rollup.config.js
+++ b/src/config/rollup.config.js
@@ -16,6 +16,7 @@ const {
   hasFile,
   hasPkgProp,
   hasAnyDep,
+  hasTypescript,
   parseEnv,
   fromRoot,
   uniq,
@@ -48,7 +49,10 @@ const peerDeps = Object.keys(pkg.peerDependencies || {})
 const defaultExternal = umd ? peerDeps : deps.concat(peerDeps)
 
 const input = glob.sync(
-  fromRoot(process.env.BUILD_INPUT || 'src/index.{js,ts,tsx}'),
+  fromRoot(
+    process.env.BUILD_INPUT ||
+      (hasTypescript ? 'src/index.{js,ts,tsx}' : 'src/index.js'),
+  ),
 )
 const codeSplitting = input.length > 1
 
@@ -139,7 +143,11 @@ const replacements = Object.entries(
   return acc
 }, {})
 
-const extensions = ['.js', '.ts', '.tsx']
+// TODO: reuse `defaults` from `node-resolve` plugin when this issue is resolved https://github.com/rollup/plugins/issues/299
+const defaultExtensions = ['.mjs', '.js', '.json', '.node']
+const extensions = hasTypescript
+  ? defaultExtensions.concat(['.ts', '.tsx'])
+  : defaultExtensions
 
 module.exports = {
   input: codeSplitting ? input : input[0],

--- a/src/utils.js
+++ b/src/utils.js
@@ -171,6 +171,7 @@ module.exports = {
   hasLocalConfig,
   hasPkgProp,
   hasScript,
+  hasDep,
   hasAnyDep,
   ifAnyDep,
   ifDep,

--- a/src/utils.js
+++ b/src/utils.js
@@ -168,6 +168,7 @@ module.exports = {
   hasLocalConfig,
   hasPkgProp,
   hasScript,
+  hasAnyDep,
   ifAnyDep,
   ifDep,
   ifDevDep,

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,6 +72,9 @@ const ifDevDep = ifPkgSubProp('devDependencies')
 const ifAnyDep = (deps, t, f) => (hasAnyDep(arrify(deps)) ? t : f)
 const ifScript = ifPkgSubProp('scripts')
 
+const hasTypescript = hasAnyDep('typescript') && hasFile('tsconfig.json')
+const ifTypescript = (t, f) => (hasTypescript ? t : f)
+
 function parseEnv(name, def) {
   if (envIsSet(name)) {
     try {
@@ -175,6 +178,8 @@ module.exports = {
   ifFile,
   ifPeerDep,
   ifScript,
+  hasTypescript,
+  ifTypescript,
   parseEnv,
   pkg,
   resolveBin,

--- a/src/utils.js
+++ b/src/utils.js
@@ -172,7 +172,6 @@ module.exports = {
   hasPkgProp,
   hasScript,
   hasDep,
-  hasAnyDep,
   ifAnyDep,
   ifDep,
   ifDevDep,


### PR DESCRIPTION
Closes #130

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Allow building TypeScript files with `kcd-scripts build --bundle` command.

Also, I've changed the default for babel's `runtimeHelpers` to `hasAnyDep('@babel/runtime')` and I'm not entirely sure why this is needed.

<!-- Why are these changes necessary? -->

**Why**:

TypeScript is awesome and we want to use it in @testing-library source code.

More in #130 and https://github.com/testing-library/dom-testing-library/issues/494

<!-- How were these changes implemented? -->

**How**:

1. Detect if project is using TypeScript by checking for `typescript` dependency and `tsconfig.json` file in root directory.
2. If TS was detected, add `@babel/preset-typescript` to default babel configuration.
3. If TS was detected, add `.ts` and `.tsx` file extensions to default rollup configuration.
4. If TS was detected, support `src/index.ts` and `src/index.tsx` entry files.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->

I'm not exactly sure what and how to test this feature but if you have any ideas, I can help. I did some smoke tests on `dom-testing-library` repo and it seemed to work out-of-the-box.

Also, I think that `kcd-scripts lint` will fail on TypeScript files when using the default configuration. https://github.com/kentcdodds/eslint-config-kentcdodds should also be updated.