### PR TITLE
run `tsc -noemit` on Typescript files during lint-staged

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ add `@babel/preset-flow` to the `presets`-section.
 
 ### TypeScript Support
 
-If the `tsconfig.json`-file is present in the project root directory and the
+If the `tsconfig.json`-file is present in the project root directory and 
 `typescript` is a dependency the `@babel/preset-typescript` will automatically
 get loaded when you use the default babel config that comes with `kcd-scripts`.
 If you customised your `.babelrc`-file you might need to manually add
@@ -133,6 +133,8 @@ If you customised your `.babelrc`-file you might need to manually add
 
 `kcd-scripts` will automatically load any `.ts` and `.tsx` files, including the
 default entry point, so you don't have to worry about any rollup configuration.
+
+`tsc --noemit` will run during lint-staged to verify that files will compile.
 
 ## Inspiration
 

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -1,4 +1,4 @@
-const {resolveKcdScripts, resolveBin} = require('../utils')
+const {resolveKcdScripts, resolveBin, ifTypescript} = require('../utils')
 
 const kcdScripts = resolveKcdScripts()
 const doctoc = resolveBin('doctoc')
@@ -10,4 +10,5 @@ module.exports = {
     `${kcdScripts} lint`,
     `${kcdScripts} test --findRelatedTests`,
   ],
+  '*.+(ts|tsx)': ifTypescript ? [`tsc --noEmit`] : undefined,
 }


### PR DESCRIPTION
**What**
For TypeScript projects, developers would like to verify that their .ts and .tsx files compile in the lint-staged stop by running
tsc -noemit

`Format`, `lint` and `test` were running on .ts and .tsc files, but nothing was checking that TypeScript code compiled correctly.

**Why**
Enable safer Typescript development

**How**
Used ifTypeScript from utils to check if TypeScript is enabled.
If enabled, run tsc --noEmilt on all .ts and .tsx files

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

I ran tests with a local project, but did not see a good way to test within this project. If you have ideas, let me know and i'll implement them. 