### PR TITLE
feat: Do not try compiling tests of types during linting

### DIFF
--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -10,5 +10,8 @@ module.exports = {
     `${kcdScripts} lint`,
     `${kcdScripts} test --findRelatedTests`,
   ],
-  '*.+(ts|tsx)': ifTypescript ? [`tsc --noEmit`] : undefined,
+  '!(types)/**/*.(ts|tsx)': ifTypescript ? [`tsc --noEmit`] : undefined,
+  'types/!(__tests__)/**/*.(ts|tsx)': ifTypescript
+    ? [`tsc --noEmit`]
+    : undefined,
 }


### PR DESCRIPTION
**What**:

Removed compiling of types tests during linting.

**Why**:

Type tests could contain "negative" tests (i.e. dtslint's `$ExpectError`). See https://github.com/testing-library/dom-testing-library/pull/572 for more context.

**How**:

I changed the globs to not include the files in `types/__tests__`. Unfortunately, I had to split up the glob into two since micromatch does not support testing for multiple consecutive directories.

**Checklist**:

- [ ] Documentation n/a
- [ ] Tests n/a
- [x] Ready to be merged
