### PR TITLE
fix: Only build typescript files in pre-commit for typescript projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ for linting, testing, building, and more.
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Installation](#installation)
 - [Usage](#usage)
   - [Overriding Config](#overriding-config)
@@ -134,7 +135,8 @@ If you customised your `.babelrc`-file you might need to manually add
 `kcd-scripts` will automatically load any `.ts` and `.tsx` files, including the
 default entry point, so you don't have to worry about any rollup configuration.
 
-`tsc --noemit` will run during lint-staged to verify that files will compile.
+`tsc --build tsconfig.json` will run during before committing to verify that files will compile.
+So make sure to add the `noEmit` flag to the `tsconfig.json`'s `compilerOptions`.
 
 ## Inspiration
 

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -1,4 +1,4 @@
-const {resolveKcdScripts, resolveBin, ifTypescript} = require('../utils')
+const {resolveKcdScripts, resolveBin} = require('../utils')
 
 const kcdScripts = resolveKcdScripts()
 const doctoc = resolveBin('doctoc')
@@ -10,5 +10,4 @@ module.exports = {
     `${kcdScripts} lint`,
     `${kcdScripts} test --findRelatedTests`,
   ],
-  '*.+(ts|tsx)': ifTypescript ? [`tsc --noEmit`] : undefined,
 }


### PR DESCRIPTION
**What**:

Currently, there is a bug in the lint-staged configuration: It checks if `ifTypescript` is truthy. Since this is a function, it will be truthy for every project. I changed the pre-commit script to move typescript compilation from lint-staged to building the whole project during pre-commit.

**Why**:

This is a follow-up on #141 and https://github.com/testing-library/dom-testing-library/pull/572. Currently, it tries to build dom testing library as a typescript project even though it is not one (it doesn't even have typescript as a dependency). This is wrong in my opinion since the reason for the ts build there is that they want to check the typescript definitions. This is already done by dtslint.

**How**:

I removed the lint-staged command for building typescript and added a typescript build to the pre-commit script.

**Checklist**:

- [x] Documentation
- [ ] Tests n/a
- [x] Ready to be merged
