### PR TITLE
fix: use jsdom jest environment and h jsx pragma for preact

### DIFF
--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -2,6 +2,7 @@ const browserslist = require('browserslist')
 const semver = require('semver')
 
 const {
+  ifDep,
   ifAnyDep,
   ifTypescript,
   parseEnv,
@@ -55,7 +56,7 @@ module.exports = () => ({
       ['react', 'preact'],
       [
         require.resolve('@babel/preset-react'),
-        {pragma: isPreact ? 'h' : undefined},
+        {pragma: isPreact ? ifDep('preact-compat', 'React.h', 'h') : undefined},
       ],
     ),
     ifTypescript([require.resolve('@babel/preset-typescript')]),

--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -55,7 +55,7 @@ module.exports = () => ({
       ['react', 'preact'],
       [
         require.resolve('@babel/preset-react'),
-        {pragma: isPreact ? 'React.h' : undefined},
+        {pragma: isPreact ? 'h' : undefined},
       ],
     ),
     ifTypescript([require.resolve('@babel/preset-typescript')]),

--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -16,7 +16,11 @@ const ignores = [
 
 const jestConfig = {
   roots: [fromRoot('src')],
-  testEnvironment: ifAnyDep(['webpack', 'rollup', 'react'], 'jsdom', 'node'),
+  testEnvironment: ifAnyDep(
+    ['webpack', 'rollup', 'react', 'preact'],
+    'jsdom',
+    'node',
+  ),
   testURL: 'http://localhost',
   moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],
   collectCoverageFrom: ['src/**/*.+(js|jsx|ts|tsx)'],


### PR DESCRIPTION
Migrating the build tools for `@testing-library/preact` to `kcd-scripts` for consistency among other testing library packages but I encountered some linting + testing issues. I think these should fix it. I tried testing locally via `npm link` but I was getting an error (`Environment key "jest/globals" is unknown`) from `esling-config-kentcdodds` and some strange modules missing errors that may be related to `npm link`.

Ref: https://github.com/testing-library/preact-testing-library/issues/24