### PR TITLE
fix: set correct jsx pragma for preact/compat

### DIFF
--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -56,7 +56,7 @@ module.exports = () => ({
       ['react', 'preact'],
       [
         require.resolve('@babel/preset-react'),
-        {pragma: isPreact ? ifDep('preact-compat', 'React.h', 'h') : undefined},
+        {pragma: isPreact ? ifDep('react', 'React.h', 'h') : undefined},
       ],
     ),
     ifTypescript([require.resolve('@babel/preset-typescript')]),


### PR DESCRIPTION
My bad @kentcdodds, `preact-compat` was used for version `8.x` which has now moved to `preact/compat`. So we can't check if the `compat` package is being used but I just replaced it with `react` which should do the trick.