### PR TITLE
fix: precommit hook on windows

### DIFF
--- a/src/config/huskyrc.js
+++ b/src/config/huskyrc.js
@@ -4,6 +4,6 @@ const kcdScripts = resolveKcdScripts()
 
 module.exports = {
   hooks: {
-    'pre-commit': `${kcdScripts} pre-commit`,
+    'pre-commit': `"${kcdScripts}" pre-commit`,
   },
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

- Make the pre commit hook work on windows
- The problem was that the path had backslashes in it and the pre-commit hook thought this was a regex. A path "C:\dev\repo\foo\husky.cmd" was translated to "C:devrepofoohusky.cmd", making that the cmd couldn't be found.


<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

- I encountered problems with it in Dom Testing Library

**How**:

<!-- Have you done all of these things?  -->
- Wrap the path between quotes 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
