### PR TITLE
feat(TS): auto-generate TypeScript definitions and add typecheck script

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ for linting, testing, building, and more.
 - [Installation](#installation)
 - [Usage](#usage)
   - [Overriding Config](#overriding-config)
-  - [Flow support](#flow-support)
   - [TypeScript Support](#typescript-support)
 - [Inspiration](#inspiration)
 - [Other Solutions](#other-solutions)
@@ -113,27 +112,23 @@ module.exports = Object.assign(jestConfig, {
 > configuring things to make it less magical and more straightforward. Extending
 > can take place on your terms. I think this is actually a great way to do this.
 
-### Flow support
-
-If the `flow-bin` is a dependency on the project the `@babel/preset-flow` will
-automatically get loaded when you use the default babel config that comes with
-`kcd-scripts`. If you customised your `.babelrc`-file you might need to manually
-add `@babel/preset-flow` to the `presets`-section.
-
 ### TypeScript Support
 
 If the `tsconfig.json`-file is present in the project root directory and
 `typescript` is a dependency the `@babel/preset-typescript` will automatically
 get loaded when you use the default babel config that comes with `kcd-scripts`.
-If you customised your `.babelrc`-file you might need to manually add
+If you customized your `.babelrc`-file you might need to manually add
 `@babel/preset-typescript` to the `presets`-section.
 
 `kcd-scripts` will automatically load any `.ts` and `.tsx` files, including the
 default entry point, so you don't have to worry about any rollup configuration.
 
-`tsc --build tsconfig.json` will run during before committing to verify that
-files will compile. So make sure to add the `noEmit` flag to the
-`tsconfig.json`'s `compilerOptions`.
+If you have a `typecheck` script (normally set to `kcd-scripts typecheck`) that
+will be run as part of the `validate` script (which is run as part of the
+`pre-commit` script as well).
+
+TypeScript definition files will also automatically be generated during the
+`build` script.
 
 ## Inspiration
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "eslint.js",
     "husky.js",
     "jest.js",
-    "prettier.js"
+    "prettier.js",
+    "shared-tsconfig.json"
   ],
   "keywords": [],
   "author": "Kent C. Dodds <me@kentcdodds.com> (https://kentcdodds.com)",

--- a/shared-tsconfig.json
+++ b/shared-tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/shared-tsconfig.json
+++ b/shared-tsconfig.json
@@ -1,5 +1,6 @@
 {
   "exclude": ["node_modules"],
+  "include": ["../../src/**/*"],
   "compilerOptions": {
     "isolatedModules": true,
     "esModuleInterop": true,

--- a/shared-tsconfig.json
+++ b/shared-tsconfig.json
@@ -7,6 +7,15 @@
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,
-    "skipLibCheck": true
+    "jsx": "react",
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "../../src",
+    "paths": {
+      "*": ["*", "../tests/*"]
+    },
+    "preserveWatchOutput": true,
+    "incremental": true,
+    "tsBuildInfoFile": "../.cache/kcd-scripts/.tsbuildinfo"
   }
 }

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -34,6 +34,7 @@ Available Scripts:
   lint
   pre-commit
   test
+  typecheck
   validate
 
 Options:

--- a/src/run-script.js
+++ b/src/run-script.js
@@ -56,7 +56,15 @@ function spawnScript() {
   // get all the arguments of the script and find the position of our script commands
   const args = process.argv.slice(2)
   const scriptIndex = args.findIndex(x =>
-    ['build', 'format', 'lint', 'pre-commit', 'test', 'validate'].includes(x),
+    [
+      'build',
+      'format',
+      'lint',
+      'pre-commit',
+      'test',
+      'validate',
+      'typecheck',
+    ].includes(x),
   )
 
   // Extract the node arguments so we can pass them to node later on

--- a/src/scripts/build/babel.js
+++ b/src/scripts/build/babel.js
@@ -4,7 +4,14 @@ const spawn = require('cross-spawn')
 const yargsParser = require('yargs-parser')
 const rimraf = require('rimraf')
 const glob = require('glob')
-const {hasPkgProp, fromRoot, resolveBin, hasFile} = require('../../utils')
+const {
+  hasPkgProp,
+  fromRoot,
+  resolveBin,
+  hasFile,
+  hasTypescript,
+  generateTypeDefs,
+} = require('../../utils')
 
 let args = process.argv.slice(2)
 const here = p => path.join(__dirname, p)
@@ -42,25 +49,42 @@ if (!useSpecifiedOutDir && !args.includes('--no-clean')) {
   args = args.filter(a => a !== '--no-clean')
 }
 
-const result = spawn.sync(
-  resolveBin('@babel/cli', {executable: 'babel'}),
-  [...outDir, ...copyFiles, ...ignore, ...extensions, ...config, 'src'].concat(
-    args,
-  ),
-  {stdio: 'inherit'},
-)
+function go() {
+  let result = spawn.sync(
+    resolveBin('@babel/cli', {executable: 'babel'}),
+    [
+      ...outDir,
+      ...copyFiles,
+      ...ignore,
+      ...extensions,
+      ...config,
+      'src',
+    ].concat(args),
+    {stdio: 'inherit'},
+  )
+  if (result.status !== 0) return result.status
 
-// because babel will copy even ignored files, we need to remove the ignored files
-const pathToOutDir = fromRoot(parsedArgs.outDir || builtInOutDir)
-const ignoredPatterns = (parsedArgs.ignore || builtInIgnore)
-  .split(',')
-  .map(pattern => path.join(pathToOutDir, pattern))
-const ignoredFiles = ignoredPatterns.reduce(
-  (all, pattern) => [...all, ...glob.sync(pattern)],
-  [],
-)
-ignoredFiles.forEach(ignoredFile => {
-  rimraf.sync(ignoredFile)
-})
+  if (hasTypescript && !args.includes('--no-ts-defs')) {
+    console.log('Generating TypeScript definitions')
+    result = generateTypeDefs()
+    console.log('TypeScript definitions generated')
+    if (result.status !== 0) return result.status
+  }
 
-process.exit(result.status)
+  // because babel will copy even ignored files, we need to remove the ignored files
+  const pathToOutDir = fromRoot(parsedArgs.outDir || builtInOutDir)
+  const ignoredPatterns = (parsedArgs.ignore || builtInIgnore)
+    .split(',')
+    .map(pattern => path.join(pathToOutDir, pattern))
+  const ignoredFiles = ignoredPatterns.reduce(
+    (all, pattern) => [...all, ...glob.sync(pattern)],
+    [],
+  )
+  ignoredFiles.forEach(ignoredFile => {
+    rimraf.sync(ignoredFile)
+  })
+
+  return result.status
+}
+
+process.exit(go())

--- a/src/scripts/build/rollup.js
+++ b/src/scripts/build/rollup.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const fs = require('fs')
 const spawn = require('cross-spawn')
 const glob = require('glob')
 const rimraf = require('rimraf')
@@ -9,6 +10,8 @@ const {
   fromRoot,
   getConcurrentlyArgs,
   writeExtraEntry,
+  hasTypescript,
+  generateTypeDefs,
 } = require('../../utils')
 
 const crossEnv = resolveBin('cross-env')
@@ -46,9 +49,9 @@ const getCommand = (env, ...flags) =>
     .join(' ')
 
 const buildPreact = args.includes('--p-react')
-const scripts = buildPreact
-  ? getPReactScripts()
-  : getConcurrentlyArgs(getCommands())
+const scripts = getConcurrentlyArgs(
+  buildPreact ? getPReactCommands() : getCommands(),
+)
 
 const cleanBuildDirs = !args.includes('--no-clean')
 
@@ -60,25 +63,56 @@ if (cleanBuildDirs) {
   }
 }
 
-const result = spawn.sync(resolveBin('concurrently'), scripts, {
-  stdio: 'inherit',
-})
+function go() {
+  let result = spawn.sync(resolveBin('concurrently'), scripts, {
+    stdio: 'inherit',
+  })
 
-if (result.status === 0 && buildPreact && !args.includes('--no-package-json')) {
-  writeExtraEntry(
-    'preact',
-    {
-      cjs: glob.sync(fromRoot('preact/**/*.cjs.js'))[0],
-      esm: glob.sync(fromRoot('preact/**/*.esm.js'))[0],
-    },
-    false,
-  )
+  if (result.status !== 0) return result.status
+
+  if (buildPreact && !args.includes('--no-package-json')) {
+    writeExtraEntry(
+      'preact',
+      {
+        cjs: glob.sync(fromRoot('preact/**/*.cjs.js'))[0],
+        esm: glob.sync(fromRoot('preact/**/*.esm.js'))[0],
+      },
+      false,
+    )
+  }
+
+  if (hasTypescript && !args.includes('--no-ts-defs')) {
+    console.log('Generating TypeScript definitions')
+    result = generateTypeDefs()
+    if (result.status !== 0) return result.status
+
+    for (const format of formats) {
+      const [formatFile] = glob.sync(fromRoot(`dist/*.${format}.js`))
+      const {name} = path.parse(formatFile)
+      // make a .d.ts file for every generated file that re-exports index.d.ts
+      fs.writeFileSync(fromRoot('dist', `${name}.d.ts`), 'export * from ".";\n')
+    }
+
+    // because typescript generates type defs for ignored files, we need to
+    // remove the ignored files
+    const ignoredFiles = [
+      ...glob.sync(fromRoot('dist', '**/__tests__/**')),
+      ...glob.sync(fromRoot('dist', '**/__mocks__/**')),
+    ]
+    ignoredFiles.forEach(ignoredFile => {
+      rimraf.sync(ignoredFile)
+    })
+    console.log('TypeScript definitions generated')
+  }
+
+  return result.status
 }
 
-function getPReactScripts() {
-  const reactCommands = prefixKeys('react.', getCommands())
-  const preactCommands = prefixKeys('preact.', getCommands({preact: true}))
-  return getConcurrentlyArgs(Object.assign(reactCommands, preactCommands))
+function getPReactCommands() {
+  return {
+    ...prefixKeys('react.', getCommands()),
+    ...prefixKeys('preact.', getCommands({preact: true})),
+  }
 }
 
 function prefixKeys(prefix, object) {
@@ -111,4 +145,4 @@ function getCommands({preact = false} = {}) {
   }, {})
 }
 
-process.exit(result.status)
+process.exit(go())

--- a/src/scripts/typecheck.js
+++ b/src/scripts/typecheck.js
@@ -1,0 +1,24 @@
+const spawn = require('cross-spawn')
+const {hasAnyDep, resolveBin, hasFile} = require('../utils')
+
+const args = process.argv.slice(2)
+
+if (!hasAnyDep('typescript')) {
+  throw new Error(
+    'Cannot use the "typecheck" script in a project that does not have typescript listed as a dependency (or devDependency).',
+  )
+}
+
+if (!hasFile('tsconfig.json')) {
+  throw new Error(
+    'Cannot use the "typecheck" script in a project that does not have a tsconfig.json file.',
+  )
+}
+
+const result = spawn.sync(
+  resolveBin('typescript', {executable: 'tsc'}),
+  ['--build', ...args],
+  {stdio: 'inherit'},
+)
+
+process.exit(result.status)

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const spawn = require('cross-spawn')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
 const arrify = require('arrify')
@@ -167,6 +168,20 @@ function hasLocalConfig(moduleName, searchOptions = {}) {
   return result !== null
 }
 
+function generateTypeDefs() {
+  return spawn.sync(
+    resolveBin('typescript', {executable: 'tsc'}),
+    // prettier-ignore
+    [
+      '--declaration',
+      '--emitDeclarationOnly',
+      '--noEmit', 'false',
+      '--outDir', fromRoot('dist'),
+    ],
+    {stdio: 'inherit'},
+  )
+}
+
 module.exports = {
   appDirectory,
   fromRoot,
@@ -175,6 +190,7 @@ module.exports = {
   hasLocalConfig,
   hasPkgProp,
   hasScript,
+  hasAnyDep,
   hasDep,
   ifAnyDep,
   ifDep,
@@ -190,4 +206,5 @@ module.exports = {
   resolveKcdScripts,
   uniq,
   writeExtraEntry,
+  generateTypeDefs,
 }


### PR DESCRIPTION
**What**: auto-generate TypeScript definitions and add typecheck script

<!-- Why are these changes necessary? -->

**Why**: To improve TypeScript support for packages using `kcd-scripts`. I think this is the last missing piece.

<!-- How were these changes implemented? -->

**How**: Update build (both babel and rollup) to add a `tsc` script to build the definitions.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
