### PR TITLE
fix: create definition files into provided folder

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -160,6 +160,17 @@ test('hasLocalConfiguration returns true if a local config found and it is empty
   expect(require('../utils').hasLocalConfig('module')).toBe(true)
 })
 
+test('should generate typescript definitions into provided folder', () => {
+  whichSyncMock.mockImplementationOnce(() => require.resolve('../'))
+  const {sync: crossSpawnSyncMock} = require('cross-spawn')
+  require('../utils').generateTypeDefs('destination folder')
+  expect(crossSpawnSyncMock).toHaveBeenCalledTimes(1)
+  const args = crossSpawnSyncMock.mock.calls[0][1]
+  const outDirIndex = args.findIndex(arg => arg === '--outDir') + 1
+
+  expect(args[outDirIndex]).toBe('destination folder')
+})
+
 function mockPkg({package: pkg = {}, path = '/blah/package.json'}) {
   readPkgUpSyncMock.mockImplementationOnce(() => ({packageJson: pkg, path}))
 }

--- a/src/scripts/build/babel.js
+++ b/src/scripts/build/babel.js
@@ -64,15 +64,16 @@ function go() {
   )
   if (result.status !== 0) return result.status
 
+  const pathToOutDir = fromRoot(parsedArgs.outDir || builtInOutDir)
+
   if (hasTypescript && !args.includes('--no-ts-defs')) {
     console.log('Generating TypeScript definitions')
-    result = generateTypeDefs()
+    result = generateTypeDefs(pathToOutDir)
     console.log('TypeScript definitions generated')
     if (result.status !== 0) return result.status
   }
 
   // because babel will copy even ignored files, we need to remove the ignored files
-  const pathToOutDir = fromRoot(parsedArgs.outDir || builtInOutDir)
   const ignoredPatterns = (parsedArgs.ignore || builtInIgnore)
     .split(',')
     .map(pattern => path.join(pathToOutDir, pattern))

--- a/src/scripts/build/rollup.js
+++ b/src/scripts/build/rollup.js
@@ -83,7 +83,7 @@ function go() {
 
   if (hasTypescript && !args.includes('--no-ts-defs')) {
     console.log('Generating TypeScript definitions')
-    result = generateTypeDefs()
+    result = generateTypeDefs(fromRoot('dist'))
     if (result.status !== 0) return result.status
 
     for (const format of formats) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -168,7 +168,7 @@ function hasLocalConfig(moduleName, searchOptions = {}) {
   return result !== null
 }
 
-function generateTypeDefs() {
+function generateTypeDefs(outputDir) {
   return spawn.sync(
     resolveBin('typescript', {executable: 'tsc'}),
     // prettier-ignore
@@ -176,7 +176,7 @@ function generateTypeDefs() {
       '--declaration',
       '--emitDeclarationOnly',
       '--noEmit', 'false',
-      '--outDir', fromRoot('dist'),
+      '--outDir', outputDir,
     ],
     {stdio: 'inherit'},
   )


### PR DESCRIPTION

**What**: Create definition files into the provided --out-dir 

<!-- Why are these changes necessary? -->

**Why**: Because definitions were always saved into `dist` folder. In @testing-lirabry/react-hooks we are using `lib` as out dir

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
