### PR TITLE
fix: remove --no-ts-defs before using babel

### DIFF
--- a/src/scripts/build/babel.js
+++ b/src/scripts/build/babel.js
@@ -42,11 +42,16 @@ const copyFiles = args.includes('--no-copy-files') ? [] : ['--copy-files']
 const useSpecifiedOutDir = args.includes('--out-dir')
 const builtInOutDir = 'dist'
 const outDir = useSpecifiedOutDir ? [] : ['--out-dir', builtInOutDir]
+const noTypeDefinitions = args.includes('--no-ts-defs')
 
 if (!useSpecifiedOutDir && !args.includes('--no-clean')) {
   rimraf.sync(fromRoot('dist'))
 } else {
   args = args.filter(a => a !== '--no-clean')
+}
+
+if (noTypeDefinitions) {
+  args = args.filter(a => a !== '--no-ts-defs')
 }
 
 function go() {
@@ -66,7 +71,7 @@ function go() {
 
   const pathToOutDir = fromRoot(parsedArgs.outDir || builtInOutDir)
 
-  if (hasTypescript && !args.includes('--no-ts-defs')) {
+  if (hasTypescript && !noTypeDefinitions) {
     console.log('Generating TypeScript definitions')
     result = generateTypeDefs(pathToOutDir)
     console.log('TypeScript definitions generated')


### PR DESCRIPTION

**What**: Remove  `--no-ts-defs` before using babel

<!-- Why are these changes necessary? -->

**Why**: Because `--no-ts-defs` doesn't exist in babel 

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
