### PR TITLE
feat: improve workspaces support

### DIFF
--- a/src/config/rollup.config.js
+++ b/src/config/rollup.config.js
@@ -145,7 +145,7 @@ module.exports = {
       mainFields: ['module', 'main', 'jsnext', 'browser'],
       extensions,
     }),
-    commonjs({include: 'node_modules/**'}),
+    commonjs({include: /node_modules/i}),
     json(),
     rollupBabel({
       presets: babelPresets,


### PR DESCRIPTION
**What**:
If you want to use workspaces the current `commonjs`-plugin configuration cause rollup not to find all the packages. The change in this commit tries to resolve this. 

**Why**:
If you are using `kcd-scripts` together with `yarn` and try to use workspaces it won't be able to find the `node_modules` directory in  all occasions this makes it more flexible by using a regular expression. 

This change should then also catch references to ../../node_modules in yarn workspaces.

**How**:
I have updated the configuration for the `commonjs`-plugin of rollup

**Checklist**:
- [ ] Documentation
- [X] Tests
- [X] Ready to be merged
