### PR TITLE
fix: remove dash from environment variables

### DIFF
--- a/src/run-script.js
+++ b/src/run-script.js
@@ -47,7 +47,7 @@ function getEnv() {
         return envCopy
       },
       {
-        [`SCRIPTS_${script.toUpperCase()}`]: true,
+        [`SCRIPTS_${script.toUpperCase().replace(/-/g, '_')}`]: true,
       },
     )
 }

--- a/src/scripts/__tests__/__snapshots__/test.js.snap
+++ b/src/scripts/__tests__/__snapshots__/test.js.snap
@@ -6,7 +6,7 @@ exports[`test does not watch --updateSnapshot 1`] = `--config {"builtInConfig":t
 
 exports[`test does not watch on CI 1`] = `--config {"builtInConfig":true}`;
 
-exports[`test does not watch on SCRIPTS_PRE-COMMIT 1`] = `--config {"builtInConfig":true}`;
+exports[`test does not watch on SCRIPTS_PRE_COMMIT 1`] = `--config {"builtInConfig":true}`;
 
 exports[`test does not watch with --coverage 1`] = `--config {"builtInConfig":true} --coverage`;
 

--- a/src/scripts/__tests__/test.js
+++ b/src/scripts/__tests__/test.js
@@ -24,9 +24,9 @@ cases(
     const {run: jestRunMock} = require('jest')
     const originalArgv = process.argv
     const prevCI = mockIsCI
-    const prevPreCommit = process.env['SCRIPTS_PRE-COMMIT']
+    const prevPreCommit = process.env.SCRIPTS_PRE_COMMIT
     mockIsCI = ci
-    process.env['SCRIPTS_PRE-COMMIT'] = preCommit
+    process.env.SCRIPTS_PRE_COMMIT = preCommit
     Object.assign(utils, {
       hasPkgProp: () => pkgHasJestProp,
       hasFile: () => hasJestConfigFile,
@@ -50,7 +50,7 @@ cases(
       // afterEach
       process.argv = originalArgv
       mockIsCI = prevCI
-      process.env['SCRIPTS_PRE-COMMIT'] = prevPreCommit
+      process.env.SCRIPTS_PRE_COMMIT = prevPreCommit
       jest.resetModules()
     }
   },
@@ -59,7 +59,7 @@ cases(
     'does not watch on CI': {
       ci: true,
     },
-    'does not watch on SCRIPTS_PRE-COMMIT': {
+    'does not watch on SCRIPTS_PRE_COMMIT': {
       preCommit: 'true',
     },
     'does not watch with --no-watch': {

--- a/src/scripts/__tests__/validate.js
+++ b/src/scripts/__tests__/validate.js
@@ -10,7 +10,7 @@ cases(
     const {sync: crossSpawnSyncMock} = require('cross-spawn')
     const originalExit = process.exit
     process.exit = jest.fn()
-    process.env['SCRIPTS_PRE-COMMIT'] = 'false'
+    process.env.SCRIPTS_PRE_COMMIT = 'false'
     const teardown = setup()
 
     try {
@@ -50,10 +50,10 @@ cases(
     },
     [`doesn't use test or lint if it's in pre-commit`]: {
       setup: withDefaultSetup(() => {
-        const previousVal = process.env['SCRIPTS_PRE-COMMIT']
-        process.env['SCRIPTS_PRE-COMMIT'] = 'true'
+        const previousVal = process.env.SCRIPTS_PRE_COMMIT
+        process.env.SCRIPTS_PRE_COMMIT = 'true'
         return function teardown() {
-          process.env['SCRIPTS_PRE-COMMIT'] = previousVal
+          process.env.SCRIPTS_PRE_COMMIT = previousVal
         }
       }),
     },

--- a/src/scripts/test.js
+++ b/src/scripts/test.js
@@ -8,7 +8,7 @@ const args = process.argv.slice(2)
 
 const watch =
   !isCI &&
-  !parseEnv('SCRIPTS_PRE-COMMIT', false) &&
+  !parseEnv('SCRIPTS_PRE_COMMIT', false) &&
   !args.includes('--no-watch') &&
   !args.includes('--coverage') &&
   !args.includes('--updateSnapshot')

--- a/src/scripts/validate.js
+++ b/src/scripts/validate.js
@@ -9,7 +9,7 @@ const {
 // pre-commit runs linting and tests on the relevant files
 // so those scripts don't need to be run if we're running
 // this in the context of a pre-commit hook.
-const preCommit = parseEnv('SCRIPTS_PRE-COMMIT', false)
+const preCommit = parseEnv('SCRIPTS_PRE_COMMIT', false)
 
 const validateScripts = process.argv[2]
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Fixes https://github.com/kentcdodds/kcd-scripts/issues/194.

Replaces dash characters (`-`) from `SCRIPTS_` environment variables with `_`.
In practice `SCRIPTS_PRE-COMMIT` is now `SCRIPTS_PRE_COMMIT`.

<!-- Why are these changes necessary? -->

**Why**:

Bash does not support environment variables with dash characters (`-`).
This cannot be reproduced with git-bash on windows but appears in Debian 10.

<!-- How were these changes implemented? -->

**How**:

When `SCRIPTS_` environment variables are added replace all dashes with underscores. 
Searched and checked all usage of `parseEnv` and `process.env`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
**Manual test:**
Without this fix I was unable to pass pre-commit hook of this repository. With the fix applied pre-commit hook runs successfully. 