### PR TITLE
chore: use jest-snapshot-serializer-raw/always as unquoteSerializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
   "homepage": "https://github.com/kentcdodds/kcd-scripts#readme",
   "devDependencies": {
     "jest-in-case": "^1.0.2",
+    "jest-snapshot-serializer-raw": "^1.2.0",
     "slash": "^3.0.0"
   }
 }

--- a/src/__tests__/index.js
+++ b/src/__tests__/index.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import slash from 'slash'
 import cases from 'jest-in-case'
-import {unquoteSerializer} from '../scripts/__tests__/helpers/serializers'
+import * as unquoteSerializer from 'jest-snapshot-serializer-raw/always'
 
 const projectRoot = path.join(__dirname, '../../')
 

--- a/src/scripts/__tests__/format.js
+++ b/src/scripts/__tests__/format.js
@@ -1,5 +1,7 @@
 import cases from 'jest-in-case'
-import {unquoteSerializer, winPathSerializer} from './helpers/serializers'
+import * as unquoteSerializer from 'jest-snapshot-serializer-raw/always'
+
+import {winPathSerializer} from './helpers/serializers'
 
 expect.addSnapshotSerializer(unquoteSerializer)
 expect.addSnapshotSerializer(winPathSerializer)

--- a/src/scripts/__tests__/helpers/serializers.js
+++ b/src/scripts/__tests__/helpers/serializers.js
@@ -1,11 +1,5 @@
 import slash from 'slash'
 
-// this removes the quotes around strings...
-export const unquoteSerializer = {
-  print: val => val,
-  test: val => typeof val === 'string',
-}
-
 // this converts windows style file paths to unix...
 export const winPathSerializer = {
   print: val => slash(val),

--- a/src/scripts/__tests__/lint.js
+++ b/src/scripts/__tests__/lint.js
@@ -1,9 +1,7 @@
 import cases from 'jest-in-case'
-import {
-  unquoteSerializer,
-  winPathSerializer,
-  relativePathSerializer,
-} from './helpers/serializers'
+import * as unquoteSerializer from 'jest-snapshot-serializer-raw/always'
+
+import {winPathSerializer, relativePathSerializer} from './helpers/serializers'
 
 expect.addSnapshotSerializer(unquoteSerializer)
 expect.addSnapshotSerializer(winPathSerializer)

--- a/src/scripts/__tests__/precommit.js
+++ b/src/scripts/__tests__/precommit.js
@@ -1,5 +1,7 @@
 import cases from 'jest-in-case'
-import {unquoteSerializer, winPathSerializer} from './helpers/serializers'
+import * as unquoteSerializer from 'jest-snapshot-serializer-raw/always'
+
+import {winPathSerializer} from './helpers/serializers'
 
 expect.addSnapshotSerializer(unquoteSerializer)
 expect.addSnapshotSerializer(winPathSerializer)

--- a/src/scripts/__tests__/test.js
+++ b/src/scripts/__tests__/test.js
@@ -1,5 +1,5 @@
 import cases from 'jest-in-case'
-import {unquoteSerializer} from './helpers/serializers'
+import * as unquoteSerializer from 'jest-snapshot-serializer-raw/always'
 
 jest.mock('jest', () => ({run: jest.fn()}))
 jest.mock('../../config/jest.config', () => ({builtInConfig: true}))

--- a/src/scripts/__tests__/validate.js
+++ b/src/scripts/__tests__/validate.js
@@ -1,5 +1,5 @@
 import cases from 'jest-in-case'
-import {unquoteSerializer} from './helpers/serializers'
+import * as unquoteSerializer from 'jest-snapshot-serializer-raw/always'
 
 expect.addSnapshotSerializer(unquoteSerializer)
 


### PR DESCRIPTION
Now that https://github.com/ikatyang/jest-snapshot-serializer-raw/pull/65 is implemented, we don't need our own version anymore