### PR TITLE
fix: use `modulePaths` to improve Jest 27 imports

### DIFF
--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const {ifAnyDep, hasFile, hasPkgProp, fromRoot} = require('../utils')
+const {ifAnyDep, hasFile, hasPkgProp} = require('../utils')
 
 const here = p => path.join(__dirname, p)
 
@@ -15,7 +15,7 @@ const ignores = [
 ]
 
 const jestConfig = {
-  roots: [fromRoot('src')],
+  roots: ['<rootDir>/src'],
   testEnvironment: ifAnyDep(
     ['webpack', 'rollup', 'react', 'preact'],
     'jsdom',
@@ -23,7 +23,7 @@ const jestConfig = {
   ),
   testURL: 'http://localhost',
   moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],
-  modulePaths: [fromRoot('src'), 'shared', fromRoot('tests')],
+  modulePaths: ['<rootDir>/src', 'shared', '<rootDir>/tests'],
   collectCoverageFrom: ['src/**/*.+(js|jsx|ts|tsx)'],
   testMatch: ['**/__tests__/**/*.+(js|jsx|ts|tsx)'],
   testPathIgnorePatterns: [...ignores],
@@ -54,7 +54,7 @@ const setupFiles = [
 ]
 for (const setupFile of setupFiles) {
   if (hasFile(setupFile)) {
-    jestConfig.setupFilesAfterEnv = [fromRoot(setupFile)]
+    jestConfig.setupFilesAfterEnv = `<rootDir>/${setupFile}`
   }
 }
 

--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -23,12 +23,7 @@ const jestConfig = {
   ),
   testURL: 'http://localhost',
   moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],
-  moduleDirectories: [
-    'node_modules',
-    fromRoot('src'),
-    'shared',
-    fromRoot('tests'),
-  ],
+  modulePaths: [fromRoot('src'), 'shared', fromRoot('tests')],
   collectCoverageFrom: ['src/**/*.+(js|jsx|ts|tsx)'],
   testMatch: ['**/__tests__/**/*.+(js|jsx|ts|tsx)'],
   testPathIgnorePatterns: [...ignores],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Use `modulePaths` to improve Jest 27 imports

<!-- Why are these changes necessary? -->

**Why**: Fixes #219 which would unblock https://github.com/testing-library/eslint-plugin-jest-dom/pull/185

<!-- How were these changes implemented? -->

**How**: 
- Moved all `moduleDirectories` (except `node_modules`) to `modulePaths`, which properly prioritizes resolving `node_modules` over local project modules
  - It's theoretically possible that this could break a test that relies on the opposite functionality, though IMO that would not be a good assumption to make, and it's worth noting that semver does not protect users from breaking changes resulting from bug fixes
- Switched to using `<rootDir>`, which should provide better support for `kcd-scripts test` in monorepos
- Ran an end to end test using `npm link` within [testing-library/eslint-plugin-jest-dom](https://github.com/testing-library/eslint-plugin-jest-dom)
  - The entire test suite now passes with Jest 26 (previously passing) and 27 (previously failing)

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
