### PR TITLE
Fix `setupFilesAfterEnv`: must be an array

### DIFF
--- a/src/config/jest.config.js
+++ b/src/config/jest.config.js
@@ -54,7 +54,7 @@ const setupFiles = [
 ]
 for (const setupFile of setupFiles) {
   if (hasFile(setupFile)) {
-    jestConfig.setupFilesAfterEnv = `<rootDir>/${setupFile}`
+    jestConfig.setupFilesAfterEnv = [`<rootDir>/${setupFile}`]
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: a string into an array

<!-- Why are these changes necessary? -->

**Why**: it breaks jest otherwise, fixes a regression from #220

<!-- How were these changes implemented? -->

**How**: added `[` and `]`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
