### PR TITLE
updated npm repo to https://registry.npmjs.org/

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=http://registry.npmjs.org/
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
**What**: updated npm repo link to use https instead of http

**Why**: as of October 4th 2021 use of TLS 1.0 and TLS 1.1 is not supported, hence http://registry.npmjs.org/ can't be used. Instead we have to use https://registry.npmjs.org/

**How**: updated link in .npmrc 

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged