### PR TITLE
fix(prettier): jsxBracketSameLine -> bracketSameLine

### DIFF
--- a/src/config/prettierrc.js
+++ b/src/config/prettierrc.js
@@ -5,7 +5,7 @@ module.exports = {
   endOfLine: 'lf',
   htmlWhitespaceSensitivity: 'css',
   insertPragma: false,
-  jsxBracketSameLine: false,
+  bracketSameLine: false,
   jsxSingleQuote: false,
   printWidth: 80,
   proseWrap: 'always',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Rename `jsxBracketSameLine` to `bracketSameLine`

<!-- Why are these changes necessary? -->

**Why**: Prettier prints deprecation warnings when using `jsxBracketSameLine`
> This release renames the `jsxBracketSameLine` option to `bracketSameLine`, which supports HTML, Vue, and Angular in addition to JSX. The old name has been deprecated.
> https://prettier.io/blog/2021/09/09/2.4.0.html

<!-- How were these changes implemented? -->

**How**: Edited Prettier config

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
