### PR TITLE
Bump Jest to 29.x and drop support for Node.js 12.x

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [12.22.0, 12, 14.17.0, 14, 16.10.0, 16, 18]
+        node: [14.17.0, 14, 16.10.0, 16, 18]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/package.json
+++ b/package.json
@@ -70,9 +70,9 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-replace": "^4.0.0",
-    "@types/jest": "^27.5.2",
+    "@types/jest": "^29.4.0",
     "arrify": "^2.0.1",
-    "babel-jest": "^28.1.3",
+    "babel-jest": "^29.4.1",
     "babel-plugin-macros": "^3.1.0",
     "babel-plugin-minify-dead-code-elimination": "^0.5.2",
     "babel-plugin-module-resolver": "^4.1.0",
@@ -92,11 +92,11 @@
     "glob": "^8.0.3",
     "husky": "^4.3.8",
     "is-ci": "^3.0.1",
-    "jest": "^28.1.3",
-    "jest-environment-jsdom": "^28.1.3",
+    "jest": "^29.4.1",
+    "jest-environment-jsdom": "^29.4.1",
     "jest-serializer-path": "^0.1.15",
     "jest-snapshot-serializer-raw": "^1.2.0",
-    "jest-watch-typeahead": "^1.1.0",
+    "jest-watch-typeahead": "^2.2.2",
     "lint-staged": "^12.5.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.has": "^4.5.2",
@@ -118,7 +118,7 @@
     "slash": "^3.0.0"
   },
   "engines": {
-    "node": "^12.22.0 || ^14.17.0 || ^16.10.0 || >=17.0.0",
+    "node": "^14.17.0 || ^16.10.0 || >=17.0.0",
     "npm": ">=6"
   }
 }

--- a/src/__tests__/__snapshots__/index.js.snap
+++ b/src/__tests__/__snapshots__/index.js.snap
@@ -4,27 +4,27 @@ exports[`format calls node with the script path and args including inspect-brk a
 
 exports[`format calls node with the script path and args: format script 1`] = `node <PROJECT_ROOT>/src/scripts/test.js --no-watch`;
 
-exports[`format does not log for other signals: format signal 1`] = `Array []`;
+exports[`format does not log for other signals: format signal 1`] = `[]`;
 
 exports[`format logs for SIGKILL signal: format signal 1`] = `
-Array [
-  Array [
+[
+  [
     The script "lint" failed because the process exited too early. This probably means the system ran out of memory or someone called \`kill -9\` on the process.,
   ],
 ]
 `;
 
 exports[`format logs for SIGTERM signal: format signal 1`] = `
-Array [
-  Array [
+[
+  [
     The script "build" failed because the process exited too early. Someone might have called \`kill\` or \`killall\`, or the system could be shutting down.,
   ],
 ]
 `;
 
 exports[`format logs help with no args: format snapshotLog 1`] = `
-Array [
-  Array [
+[
+  [
     
 Usage: ../ [script] [--flags]
 

--- a/src/__tests__/__snapshots__/utils.js.snap
+++ b/src/__tests__/__snapshots__/utils.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getConcurrentlyArgs gives good args to pass to concurrently 1`] = `
-Array [
+[
   --kill-others-on-fail,
   --prefix,
   [{name}],


### PR DESCRIPTION
BREAKING CHANGE: Drops support for Node.js 12x. Updates Jest to 29.x

Needs update for required GH checks (since 12.x is no longer tested)

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Drops support for Node.js 12x. Updates Jest to 29.x

**Why**:

Updating Jest to 29.x pulls in JSDOM 20.x which no longer supports Node.js 12.x

**How**:

Bump dependencies from the Jest monorepo and update snapshots

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
