### PR TITLE
Fix: Preact build doesn't work due to incorrect Preact imports

### DIFF
--- a/src/config/babelrc.js
+++ b/src/config/babelrc.js
@@ -19,7 +19,10 @@ const isCJS = BUILD_FORMAT === 'cjs'
 const isWebpack = parseEnv('BUILD_WEBPACK', false)
 const isMinify = parseEnv('BUILD_MINIFY', false)
 const treeshake = parseEnv('BUILD_TREESHAKE', isRollup || isWebpack)
-const alias = parseEnv('BUILD_ALIAS', isPreact ? {react: 'preact'} : null)
+const alias = parseEnv(
+  'BUILD_ALIAS',
+  isPreact ? {react: 'preact/compat'} : null,
+)
 
 const hasBabelRuntimeDep = Boolean(
   pkg.dependencies && pkg.dependencies['@babel/runtime'],


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Preact build doesn't work due to incorrect Preact imports

<!-- Why are these changes necessary? -->

**Why**:  downshift is not working with preact

<!-- How were these changes implemented? -->

**How**: I had to go through the build process and change import alias from "preact" to "preact/compat"

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

Steps I followed to test:

1. Made the alias change for kcd-scripts in downshift node_modules
2. I ran the build and copied preact build output in a sample preact app
3. It started working :)

Downshift issues related to this:
1. https://github.com/downshift-js/downshift/issues/1430
2. https://github.com/downshift-js/downshift/issues/1198
