### PR TITLE
fix(utils): setup extension by format in getRollupOutput (maybe breaking-change)

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -190,3 +190,17 @@ function mockCosmiconfig(result = null) {
 
   cosmiconfigSync.mockImplementationOnce(() => ({search: () => result}))
 }
+
+test.each([
+  {format: 'cjs', extension: '.cjs'},
+  {format: 'esm', extension: '.mjs'},
+  {format: 'umd', extension: '.js'},
+  {format: 'amd', extension: '.js'},
+])(
+  'file extension in rollupOutput with $format should be $extension',
+  ({format, extension}) => {
+    expect(
+      require('../utils').getRollupOutput(format).filename.endsWith(extension),
+    ).toBeTruthy()
+  },
+)

--- a/src/utils.js
+++ b/src/utils.js
@@ -210,12 +210,17 @@ function getRollupInputs() {
 function getRollupOutput(format = process.env.BUILD_FORMAT) {
   const minify = parseEnv('BUILD_MINIFY', false)
   const filenameSuffix = process.env.BUILD_FILENAME_SUFFIX || ''
+  const ext =
+    {
+      esm: '.mjs',
+      cjs: '.cjs',
+    }[format] || '.js'
   const filename = [
     pkg.name,
     filenameSuffix,
     `.${format}`,
     minify ? '.min' : null,
-    '.js',
+    ext,
   ]
     .filter(Boolean)
     .join('')


### PR DESCRIPTION
**What**:
Set build output file extension by target format.

**Why**:
https://github.com/testing-library/react-testing-library/issues/1338
I looking for a solution to this issue.
First of all, the issue was different from `testing-library/dom`, which is referred to in `testing-library/react`, and `testing-library/dom`, which is referred to in `testing-library/user-event`.
So I solved this problem by changing the extension of the esm file to `.mjs`.

`testing-library` was using that library as a build tool, and found out that within that library they were building extensions as fixed as `.js` and are trying to fix it.

### Screenshot
#### Before change extension
![Screenshot 2024-07-11 at 11 29 48 PM](https://github.com/kentcdodds/kcd-scripts/assets/66503450/bab328f6-c5f7-4477-bf22-607c6523125a)
After configure in `testing-library/react`, but `getConfig().eventWrapper` in `testing-library/user-event` is default function.

#### After change extension
![Screenshot 2024-07-11 at 11 52 11 PM](https://github.com/kentcdodds/kcd-scripts/assets/66503450/10836f6a-d751-4a2f-9f9f-4776ec47dda3)
After configure in `testing-library/react`, so `getConfig().eventWrapper` in `testing-library/user-event` is configured function.

**How**:
Set file extension string using format parameter.

<!-- Have you done all of these things?  -->

**Checklist**:

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged

